### PR TITLE
アンカーの追加チェーン無しバージョン　それに伴う一部の変更

### DIFF
--- a/anchor.cpp
+++ b/anchor.cpp
@@ -1,0 +1,324 @@
+#include"include/box2d/box2d.h"
+#include"anchor.h"
+#include"sprite.h"
+#include"texture.h"
+#include"player_position.h"
+#include"player.h"
+#include"anchor_point.h"
+#include"world_box2d.h"
+#include"collider_type.h"
+#include"contactlist.h"
+
+//グローバル変数
+static ID3D11ShaderResourceView* g_Anchor_Texture = NULL;//アンカーのテクスチャ
+static ID3D11ShaderResourceView* g_Anchor_Chain_Texture = NULL;//アンカーの鎖のテクスチャ
+
+//アンカーの一端のプレイヤーのボディをもっとく
+b2Body* Player_body;
+
+//アンカーの目標のアンカーポイント
+b2Body* Target_anchor_point_body;
+
+
+
+//アンカーの鎖の部分のボディの入れ物
+b2Body* anchor_chain[20];
+
+//アンカークラスのインスタンス
+Anchor*g_anchor_instance;
+
+
+Anchor::Anchor()
+{
+	anchor_create_joint_flag = false;
+}
+
+Anchor::~Anchor()
+{
+	DestroyAnchorBody();
+}
+
+
+void Anchor::Initialize()
+{
+	//テクスチャの初期化
+
+	//アンカーの錨の部分（日本語）
+	g_Anchor_Texture=InitTexture(L"asset\\texture\\sample_texture\\img_anchor.png");
+
+	//アンカーの鎖
+	g_Anchor_Chain_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_yellow.png");
+}
+
+void Anchor::CreateAnchor(b2Vec2 anchor_size)
+{
+	if (g_anchor_instance == nullptr)
+	{
+		g_anchor_instance = new Anchor();//NULLだったらアンカーを作って上げる
+	}
+	g_anchor_instance->CreateAnchorBody(anchor_size);//アンカーのボディをつくる
+}
+
+void Anchor::DeleteAnchor()
+{
+	if (g_anchor_instance != nullptr) {
+		g_anchor_instance->DestroyAnchorBody();
+	
+		//配列自体もデリート
+		delete g_anchor_instance;
+		//NULLもしとく
+		g_anchor_instance = nullptr;
+
+	}
+	
+}
+void Anchor::ToggleAnchor()
+{
+	if (g_anchor_instance != nullptr && g_anchor_instance->GetAnchorBody() != nullptr) {
+		DeleteAnchor();
+	}
+	else {
+		CreateAnchor(b2Vec2(2.0f,2.0f));
+	}
+}
+
+
+void Anchor::CreateAnchorBody(b2Vec2 anchor_size)
+{
+	//アンカーの錨の部分を作ってあげちゃう
+	b2Body* player_body = Player::GetOutSidePlayerBody();			//プレイヤーのBody情報を取得
+	b2Body* target_AP_body = AnchorPoint::GetTargetAnchorPointBody();//ターゲットとしたアンカーポイントのボディ情報を取得
+
+
+	b2BodyDef body;
+	body.type = b2_dynamicBody;
+	body.position.Set(player_body->GetPosition().x + 0.5, player_body->GetPosition().y - 0.5);
+	body.angle = 0.0f;
+	body.fixedRotation = true;//回転を固定にする
+	body.userData.pointer = (uintptr_t)this;
+
+
+
+
+	Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+	b2World* world = box2d_world.GetBox2dWorldPointer();
+
+
+
+	m_body = world->CreateBody(&body);
+
+	player_body = m_body;//プレイヤーのボディをセット
+
+
+	SetSize(anchor_size);//プレイヤー表示をするためにセットする
+
+
+
+
+
+	b2Vec2 size;
+	size.x = anchor_size.x / BOX2D_SCALE_MANAGEMENT;//サイズを１にすると　1m*1mになるため　サイズをさげて、物理演算の挙動を操作しやすくする
+	size.y = anchor_size.y / BOX2D_SCALE_MANAGEMENT;
+
+
+	b2PolygonShape shape;
+	shape.SetAsBox(size.x * 0.5, size.y * 0.5f);
+
+
+
+	b2FixtureDef fixture;
+	fixture.shape = &shape;
+	fixture.density = 0.1f;//密度
+	fixture.friction = 0.05f;//摩擦
+	fixture.restitution = 0.1f;//反発係数
+	fixture.isSensor = true;//センサーかどうか、trueならあたり判定は消える
+
+
+
+
+	b2Fixture* player_fixture = m_body->CreateFixture(&fixture);
+
+	// カスタムデータを作成して設定
+	// プレイヤーに値を登録
+	// プレーヤーにユーザーデータを登録
+	ObjectData* playerdata = new ObjectData{ collider_anchor };
+	player_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(playerdata);
+
+
+}
+
+void Anchor::DestroyAnchorBody()
+{
+	if (m_body != nullptr) {
+		if (m_body != nullptr) {
+			Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+			b2World* world = box2d_world.GetBox2dWorldPointer();
+			world->DestroyBody(m_body);
+			m_body = nullptr;
+			m_isAnchorCreated = false;
+		}
+	}
+}
+
+void Anchor::Update()
+{
+
+	
+	if(Anchor::GetAnchorState()==Connected_state)//くっついている状態になったら
+	{
+		g_anchor_instance->GetAnchorBody()->SetLinearVelocity(b2Vec2_zero);
+
+		Anchor::CreateRotateJoint();
+
+		Anchor::SetAnchorState(Pulling_state);
+	}
+}
+
+void Anchor::Draw()
+{
+
+	// スケールをかけないとオブジェクトのサイズの表示が小さいから使う
+	float scale = SCREEN_SCALE;
+
+	// スクリーン中央位置 (プロトタイプでは乗算だったけど　今回から加算にして）
+	b2Vec2 screen_center;
+	screen_center.x = SCREEN_CENTER_X;
+	screen_center.y = SCREEN_CENTER_Y;
+
+
+	if (g_anchor_instance == nullptr)
+	{
+		return;
+	}
+
+	b2Body *anchor = g_anchor_instance->GetAnchorBody();
+
+	if (anchor!= nullptr)
+	{
+		b2Vec2 position;
+		position.x = anchor->GetPosition().x;
+		position.y = anchor->GetPosition().y;
+
+		// プレイヤー位置を考慮してスクロール補正を加える
+		//取得したbodyのポジションに対してBox2dスケールの補正を加える
+		float draw_x = ((position.x - PlayerPostion::GetPlayerPostion().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
+		float draw_y = ((position.y - PlayerPostion::GetPlayerPostion().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
+
+
+		GetDeviceContext()->PSSetShaderResources(0, 1, &g_Anchor_Chain_Texture);
+
+		//draw
+		DrawSprite(
+			{ draw_x,
+			  draw_y },
+			g_anchor_instance->GetAnchorBody()->GetAngle(),
+			{ g_anchor_instance->GetSize().x*scale,g_anchor_instance->GetSize().y*scale}///サイズを取得するすべがない　フィクスチャのポインターに追加しようかな？ってレベル
+		);
+	}
+	
+}
+
+
+void Anchor::Finalize()
+{
+
+}
+
+
+
+
+
+void Anchor::ThrowAnchorToAP()
+{
+	if (g_anchor_instance == nullptr)
+	{
+		return;//NULLチェック
+	}
+
+	//今のアンカーがある座標の取得
+	b2Vec2 anchor_pos=g_anchor_instance->GetAnchorBody()->GetPosition();
+
+	//対象となるAPの座標を取得する
+	b2Vec2 to_pos = AnchorPoint::GetTargetAnchorPointBody()->GetPosition();
+
+	b2Vec2 velocity = to_pos - anchor_pos;
+	velocity.Normalize(); // 単位ベクトル化して方向を決定
+	velocity *= 20; // 投擲速度を設定	
+
+	g_anchor_instance->GetAnchorBody()->SetLinearVelocity(velocity);//ここで力を加えてる
+
+}
+	
+void Anchor::CreateRotateJoint()
+{
+	MyContactListener& contact_listener = MyContactListener::GetInstance();
+
+	if (g_anchor_instance == nullptr || g_anchor_instance->GetAnchorBody() == nullptr) {
+		return; // アンカーが存在しない場合は何もしない
+	}
+
+	b2Body* anchorBody = g_anchor_instance->GetAnchorBody();
+	b2Body* targetBody = AnchorPoint::GetTargetAnchorPointBody();
+
+	if (anchorBody == nullptr || targetBody == nullptr) {
+		return; // ターゲットが存在しない場合は何もしない
+	}
+
+	// 回転ジョイントを定義
+	b2RevoluteJointDef jointDef;
+	jointDef.bodyA = anchorBody;
+	jointDef.bodyB = targetBody;
+
+	// ジョイントのアンカー点を設定 (例: アンカーの位置に合わせる)
+	b2Vec2 localAnchorA = anchorBody->GetLocalPoint(contact_listener.contactPoint);
+	b2Vec2 localAnchorB = targetBody->GetLocalPoint(contact_listener.contactPoint);
+
+	jointDef.collideConnected = true; // ジョイントで接続されたボディ間の衝突を無効化
+
+	// ジョイントを生成
+	Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+	b2World* world = box2d_world.GetBox2dWorldPointer();
+	world->CreateJoint(&jointDef);
+}
+
+void Anchor::PullingAnchor(void)
+{
+	//プレイヤーとアンカーの座標を取得する
+
+	b2Vec2 player_postion = PlayerPostion::GetPlayerPostion();
+	b2Vec2 anchor_postion = g_anchor_instance->GetAnchorBody()->GetPosition();
+
+	b2Vec2 velocity = player_postion - anchor_postion;
+	velocity.Normalize(); // 単位ベクトル化して方向を決定
+	velocity *= 3; // 投擲速度を設定	
+
+	g_anchor_instance->GetAnchorBody()->SetLinearVelocity(velocity);
+
+}
+
+
+
+// 静的メンバ変数の定義
+bool Anchor::anchor_create_joint_flag = false;
+
+void Anchor::SetAnchorCreateJointFlag(bool flag) {
+	anchor_create_joint_flag = flag;
+}
+
+bool Anchor::GetAnchorCreateJointFlag() {
+	return anchor_create_joint_flag;
+}
+
+
+//静的メンバの変数の定義
+AnchorState Anchor::now_anchor_state = Nonexistent_state;
+
+void Anchor::SetAnchorState(AnchorState state)
+{
+	now_anchor_state = state;
+}
+
+AnchorState Anchor::GetAnchorState()
+{
+	return now_anchor_state;
+}

--- a/anchor.h
+++ b/anchor.h
@@ -1,0 +1,120 @@
+#ifndef ANCHOR_H
+#define ANCHOR_H
+
+
+enum AnchorState
+{
+	Nonexistent_state,	//存在しない状態
+	Create_state,		//作成している状態
+	Throwing_state,		//投げている状態　 Throwを呼び出す
+	Connected_state,	//くっついている状態
+	Pulling_state,		//引っ張っている状態
+	Deleting_state,
+};
+
+
+class Anchor
+{
+public:
+	Anchor();//コンストラクタでは生成しない
+	~Anchor();
+
+	static void Initialize();
+	static void Update();
+	static void Draw();
+	static void Finalize();
+
+	/**
+	* @brief アンカーを投げる処理
+	* アンカー自身と目標となる座標を取得して、目標の座標に飛ばす
+	*/
+	static void ThrowAnchorToAP();
+
+	/**
+	 * @brief アンカーを引っ張る
+	 */
+	static void PullingAnchor(void);
+
+	/**
+	 * @brief アンカーを生成する
+	 * @param size 生成するアンカーの大きさ
+	 */
+	static void CreateAnchor(b2Vec2 size);
+
+	/**
+	 * @brief アンカーのボディを生成する
+	 * @param anchor_size 生成するするアンカー大きさ
+	 */
+	void CreateAnchorBody(b2Vec2 anchor_size);
+
+	/**
+	 * @brief アンカーのボディを削除する
+	 */
+	void DestroyAnchorBody();//Bodyを削除する
+
+	/**
+	 * @brief アンカーを削除する
+	 */
+	static void DeleteAnchor();
+
+	/**
+	 * @brief アンカーの生成と削除を管理する関数
+	 */
+	static void ToggleAnchor();
+
+
+	/**
+	 * @brief  ぶつかったら回転ジョイントを付ける
+	 */
+	static void CreateRotateJoint();
+
+
+
+	b2Body* GetAnchorBody(void)
+	{
+		return m_body;
+	}
+
+	void SetAnchorBody(b2Body* anchor_body)
+	{
+		m_body = anchor_body;
+	}
+
+
+	//描画用にサイズを持たせておく
+	b2Vec2 GetSize() const
+	{
+		return m_p_size;
+	}
+
+	void SetSize(b2Vec2 size)
+	{
+		m_p_size = size;
+	}
+
+	static void SetAnchorCreateJointFlag(bool flag);
+	static bool GetAnchorCreateJointFlag();
+	
+	static void SetAnchorState(AnchorState state);
+	static AnchorState GetAnchorState();
+
+private:
+	//プレイヤーのBodyをもつ
+	b2Body* m_body;
+
+	b2Vec2 m_p_size;
+
+	bool m_isAnchorCreated = false; // ボディが生成されているか管理
+
+	static bool anchor_create_joint_flag;
+
+
+	static AnchorState now_anchor_state;
+};
+
+
+
+
+
+#endif // !ANCHOR_H
+

--- a/anchor_point.cpp
+++ b/anchor_point.cpp
@@ -21,7 +21,7 @@
 
 b2Body* g_anchor_point_body[10];//アンカーポイントのボディを設定　グローバル変数
 
-b2Body* g_select_anchor_point_body;
+b2Body* g_select_anchor_point_body;//ターゲットとなるアンカーポイントのボディ
 
 
 
@@ -48,7 +48,7 @@ AnchorPoint::AnchorPoint(b2Vec2 position, b2Vec2 body_size, float angle, bool bF
 	body.position.Set(position.x, position.y);			//ポジションをセット
 	body.angle = angle;									//角度の定義
 	body.userData.pointer = (uintptr_t)this;			//userDataのポインタを定義 
-	body.fixedRotation = true;							//回転を固定する、　これをオンにすると回転しない
+	body.fixedRotation = false;							//回転を固定する、　これをオンにすると回転しない
 
 
 	Box2dWorld& box2d_world = Box2dWorld::GetInstance();//ワールドのインスタンスを取得する
@@ -119,7 +119,13 @@ void AnchorPoint::OutsideSensor(b2Body* delete_anchor_point_body)
 			//選択していたアンカーポイントがセンサー外にでた
 			if (delete_anchor_point_body == g_select_anchor_point_body)
 			{
-				g_select_anchor_point_body = nullptr;
+				//アンカーが当たったアンカーポイントがぶつかって、センサー外にでると、
+				//座標更新でアンカーとアンカーポイントとプレイヤーが一体化したバグが発生　おい笑える
+				//応急処置として、アンカーポイントがジョイントしてないときに発動するようにした
+				if (Anchor::GetAnchorCreateJointFlag() != true)
+				{
+					g_select_anchor_point_body = nullptr;
+				}
 			}
 			return;
 		}
@@ -137,8 +143,14 @@ void AnchorPoint::Update()
 	//選択しているアンカーポイントがなかったら、playerのBodyを基準点にする
 	if (g_select_anchor_point_body == nullptr)
 	{
-		Player& player = Player::GetInstance();//ゲットインスタンス
-		g_select_anchor_point_body = player.GetPlayerBody();
+		//アンカーが当たったアンカーポイントがぶつかって、センサー外にでると、
+		//座標更新でアンカーとアンカーポイントとプレイヤーが一体化したバグが発生　おい笑える
+		//応急処置として、アンカーポイントがジョイントしてないときに発動するようにした
+		if (Anchor::GetAnchorCreateJointFlag() != true)
+		{
+			Player& player = Player::GetInstance();//ゲットインスタンス
+			g_select_anchor_point_body = player.GetPlayerBody();
+		}
 	}
 
 	
@@ -169,8 +181,8 @@ void AnchorPoint::Draw()
 
 			// プレイヤー位置を考慮してスクロール補正を加える
 			//取得したbodyのポジションに対してBox2dスケールの補正を加える
-			float draw_x = ((position.x - PlayerPosition::GetPlayerPosition().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
-			float draw_y = ((position.y - PlayerPosition::GetPlayerPosition().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
+			float draw_x = ((position.x - PlayerPostion::GetPlayerPostion().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
+			float draw_y = ((position.y - PlayerPostion::GetPlayerPostion().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
 
 
 			GetDeviceContext()->PSSetShaderResources(0, 1, &g_anchor_point_target_Texture);
@@ -191,8 +203,8 @@ void AnchorPoint::Draw()
 
 	// プレイヤー位置を考慮してスクロール補正を加える
 	//取得したbodyのポジションに対してBox2dスケールの補正を加える
-	float draw_x = ((position.x - PlayerPosition::GetPlayerPosition().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
-	float draw_y = ((position.y - PlayerPosition::GetPlayerPosition().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
+	float draw_x = ((position.x - PlayerPostion::GetPlayerPostion().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
+	float draw_y = ((position.y - PlayerPostion::GetPlayerPostion().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
 
 
 	GetDeviceContext()->PSSetShaderResources(0, 1, &g_anchor_point_target_Texture);
@@ -264,3 +276,10 @@ void AnchorPoint::SelectAnchorPoint(float stick_x, float stick_y)
 	}
 }
 
+
+
+
+b2Body* AnchorPoint::GetTargetAnchorPointBody()
+{
+	return g_select_anchor_point_body;
+}

--- a/contactlist.h
+++ b/contactlist.h
@@ -4,14 +4,17 @@
 #include"include/box2d/box2d.h"
 #include"collider_type.h"
 #include"anchor_point.h"
+#include"anchor.h"
 
 
 
 
 class MyContactListener : public b2ContactListener {
-public:
-   
+private:
 
+public:
+    b2Vec2 contactPoint;
+   
 
     // シングルトンのインスタンスを取得する
     static MyContactListener& GetInstance() {
@@ -19,8 +22,10 @@ public:
         return instance;
     }
 
+  
 
-
+  
+ 
 
     // 衝突した瞬間
     void BeginContact(b2Contact* contact) override {
@@ -78,7 +83,20 @@ public:
             AnchorPoint::InsideSensor(anchor_point_body);
            
         }
-        
+        //プレイヤーに付属しているセンサーとアンカーポイントが触れた場合
+        if ((objectA->collider_type == collider_anchor && objectB->collider_type == collider_anchor_point) ||
+            (objectA->collider_type == collider_anchor_point && objectB->collider_type == collider_anchor))
+        {
+
+
+            Anchor::SetAnchorState(Connected_state);//プレイヤーアップデートの中のスイッチ文の移行よう 接続状態に移行
+
+            // 接触位置を取得
+            b2WorldManifold worldManifold;
+            contact->GetWorldManifold(&worldManifold);
+            contactPoint = worldManifold.points[0];
+        }
+
      
     }
 

--- a/player.cpp
+++ b/player.cpp
@@ -5,8 +5,6 @@
 // #update 2024/11/03
 // #comment 追加・修正予定
 //          ・コンストラクタでbodyとfixture作ってInitializeでつくる
-//          ・
-//           
 //----------------------------------------------------------------------------------------------------
 
 
@@ -21,16 +19,28 @@
 #include"keyboard.h"
 #include<Windows.h>
 #include"player_position.h"
+#include"collider_type.h"
+#include"anchor_point.h"
+#include"anchor.h"
 
 //テクスチャのダウンロード グローバル変数にしてる
-ID3D11ShaderResourceView* g_player_Texture;
+ID3D11ShaderResourceView* g_player_Texture=NULL;
+
+
+//センサーの画像
+ID3D11ShaderResourceView* g_player_sensor_Texture=NULL;
 
 
 
 //プレーヤーのポインターをNULLに
 Player *player=nullptr;
 
-Player::Player(b2Vec2 position, b2Vec2 body_size) :m_body(nullptr)
+b2Body* player_body;
+
+
+int g_anchor_pulling_number = 0;
+
+Player::Player(b2Vec2 position, b2Vec2 body_size,b2Vec2 sensor_size) :m_body(nullptr)
 {
 
     b2BodyDef body;
@@ -40,18 +50,34 @@ Player::Player(b2Vec2 position, b2Vec2 body_size) :m_body(nullptr)
     body.fixedRotation = true;//回転を固定にする
     body.userData.pointer = (uintptr_t)this;
 
+
+    
+
     Box2dWorld& box2d_world = Box2dWorld::GetInstance();
     b2World* world = box2d_world.GetBox2dWorldPointer();
 
+
+
     m_body = world->CreateBody(&body);
 
-   
-    SetSize(body_size);//表示をするためにセットする
+    player_body = m_body;//プレイヤーのボディをセット
 
+   
+    SetSize(body_size);//プレイヤー表示をするためにセットする
+    SetSensorSize(sensor_size);//センサー表示をするためにセット
+
+
+    
+ 
     b2Vec2 size;
     size.x = body_size.x/BOX2D_SCALE_MANAGEMENT;//サイズを１にすると　1m*1mになるため　サイズをさげて、物理演算の挙動を操作しやすくする
     size.y = body_size.y/BOX2D_SCALE_MANAGEMENT;
 
+
+    //センサーの設定用の
+    b2Vec2 size_sensor;//命名すまん
+    size_sensor.x=sensor_size.x / BOX2D_SCALE_MANAGEMENT;
+    size_sensor.y=sensor_size.y / BOX2D_SCALE_MANAGEMENT;
 
 
     b2PolygonShape shape;
@@ -66,7 +92,44 @@ Player::Player(b2Vec2 position, b2Vec2 body_size) :m_body(nullptr)
     fixture.restitution = 0.1f;//反発係数
     fixture.isSensor = false;//センサーかどうか、trueならあたり判定は消える
 
-    m_body->CreateFixture(&fixture);
+  
+
+   
+    b2Fixture* player_fixture =m_body->CreateFixture(&fixture);
+
+    // カスタムデータを作成して設定
+    // プレイヤーに値を登録
+    // プレーヤーにユーザーデータを登録
+    ObjectData* playerdata = new ObjectData{collider_player};
+    player_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(playerdata);
+
+  
+    //--------------------------------------------------------------------------------------------------
+    
+    //プレイヤーのセンサーを新しくつくる
+
+    b2PolygonShape shape_sensor;
+    shape_sensor.SetAsBox(size_sensor.x * 0.5, size_sensor.y * 0.5);
+
+
+
+    b2FixtureDef fixture_sensor;
+    fixture_sensor.shape = &shape_sensor;
+    fixture_sensor.density = 0.0f;//密度
+    fixture_sensor.friction = 0.0f;//摩擦
+    fixture_sensor.restitution = 0.0f;//反発係数
+    fixture_sensor.isSensor = true;//センサーかどうか、trueならあたり判定は消える
+ 
+    b2Fixture* player_sensor_fixture = m_body->CreateFixture(&fixture_sensor);
+
+
+    // カスタムデータを作成して設定
+   // プレイヤーに値を登録
+   // プレーヤーにユーザーデータを登録
+    ObjectData* player_sensor_data = new ObjectData{ collider_player_sensor };
+    player_sensor_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(player_sensor_data);
+
+    //---------------------------------------------------------------------------------------------------
 }
 
 
@@ -82,11 +145,10 @@ void Player::Initialize()
     //テクスチャのロード
     g_player_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_blue.png");
 
-    if (player == nullptr)
-    {
-        //プレイヤーのインスタンスをつくった！
-        player = new Player(b2Vec2(10.0f, 0.0f), b2Vec2(1.0f, 1.0f));
-    }
+    g_player_sensor_Texture= InitTexture(L"asset\\texture\\sample_texture\\img_sensor.png");
+
+
+    
 
 }
 
@@ -112,7 +174,7 @@ void Player::Update()
 
 
     //コントローラーでの受け取り 横移動
-    m_body ->ApplyForceToCenter(b2Vec2(state.leftStickX / 800, 0.0), true);
+    m_body ->ApplyForceToCenter(b2Vec2(state.leftStickX / 20000, 0.0), true);
 
 
     //ジャンプチェック
@@ -123,10 +185,73 @@ void Player::Update()
 
     }
 
+ //アンカーの処理
+//----------------------------------------------------------------------------------------------------------------------------------------------------
 
+    if ((Keyboard_IsKeyDown(KK_T) || (state.buttonB))&&Anchor::GetAnchorState()==Nonexistent_state)//何も存在しない状態でボタン入力で移行する
+    {
+        Anchor::SetAnchorState(Create_state);//作成状態に移行
+    }
+
+    switch (Anchor::GetAnchorState())
+    {
+    case Nonexistent_state://何もない状態
+        //ここからの移行は上のボタンで管理
+        break;
+    case Create_state:
+        Anchor::CreateAnchor(b2Vec2(2.0f, 2.0f));//ここの引数でアンカーの大きさの調整ができるよー
+        Anchor::SetAnchorState(Throwing_state);//アンカーの状態を投げるている状態に移行
+        break;
+    case Throwing_state://錨が飛んでいる状態
+        Anchor::ThrowAnchorToAP();//アンカーをターゲットとしたアンカーポイントに向かって投げる関数
+        //ここはコンタクトリストないの接触判定から接触状態へと移行
+        break;
+    case Connected_state://物体がくっついた状態　ジョイントの作成
+        Anchor::CreateRotateJoint();//回転ジョイントを作成
+        Anchor::SetAnchorState(Pulling_state);//引っ張り状態に移行
+        break;
+
+    case Pulling_state://引っ張っている状態
+        Anchor::PullingAnchor();//ぶつかったアンカーを引っ張る
+        //ここの判定の仕方どうしようかな？？
+        //呼ばれた回数でするかね　とりあえず2秒で
+
+        if (g_anchor_pulling_number > 120)
+        {
+            Anchor::SetAnchorState(Deleting_state);//状態をアンカーを削除する状態に移行
+
+            g_anchor_pulling_number = 0;//値をリセット
+        }
+        g_anchor_pulling_number++;
+        
+
+        break;
+
+    case Deleting_state://削除している状態
+        Anchor::DeleteAnchor();//アンカーを削除
+        Anchor::SetAnchorState(Nonexistent_state);
+
+        break;
+
+    default:
+        break;
+    }
+
+ //---------------------------------------------------------------------------------------------------------------------------------------------------------------------  
+
+    //スティックの値を受け取って正規化する
+    float stick_x= state.rightStickX / 32768.0f;
+    float stick_y= state.rightStickY / 32768.0f;
+
+    //絶対値に変更する デットゾーンの審査に使うため　tool.cppに作った
+    //デットゾーンをつくる x,yの値を足して一定以上経ったら　呼び出し
+    if (0.98 < ReturnAbsoluteValue(stick_x) + ReturnAbsoluteValue(stick_y))
+    {
+        AnchorPoint::SelectAnchorPoint(stick_x, stick_y);
+    }
 
     //プレイヤーポジションCPPの関数にデータをセット
-    PlayerPosition::SetPlayerPosition(m_body->GetPosition());
+    PlayerPostion::SetPlayerPostion(m_body->GetPosition());
 }
 
 void Player::Draw()
@@ -159,7 +284,22 @@ void Player::Draw()
         {GetSize().x* scale,GetSize().y * scale }
     );
 
+    //----------------------------------------------------------------------------------------
+    //センサー描画
 
+
+    // シェーダリソースを設定
+    GetDeviceContext()->PSSetShaderResources(0, 1, &g_player_sensor_Texture);
+
+    DrawSprite(
+        { screen_center.x,
+          screen_center.y },
+        m_body->GetAngle(),
+        { GetSensorSize().x * scale,GetSensorSize().y * scale }
+    );
+    float size_sensor = GetSensorSize().x * scale;
+    float size = GetSize().x * scale;
+  
 }
 
 void Player::Finalize()
@@ -175,4 +315,11 @@ void Player::Finalize()
     {
         UnInitTexture(g_player_Texture);
     }
+}
+
+
+//ボディを外部から取得するために作った関数
+b2Body* Player::GetOutSidePlayerBody()
+{
+    return player_body;
 }


### PR DESCRIPTION
追加点
アンカーCPPヘッダーの追加

それに伴うPlayercpp_updateでのアンカー処理の追加
またアンカーの引っ張り状態を管理するグローバル変数をCPPの上部に追加

アンカーポイントCPPの追加
アンカーヘッダーのインクルード
錨を刺した状態でセンサー外にでると
アンカーポイント、プレイヤー、アンカーが一体化するバグの発生。
その対応のためアンカーポイントCPPないの
OutsideSensor,Updata内にバグ修正を追加

Contactlist.hに追加定義
パブリックのメンバ変数として、b2vec2 ContactPointを追加classの一番上ね

BiginContact内にアンカーポイントとアンカーが触れた場合の処理を追加

以上抜けがあったらごめん　いつでも聞いてもらえればと

本日の
クレーン乗せてくれーん？