### PR TITLE
追加：レベルに応じた画面の縮小拡大

### DIFF
--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="create_filter.cpp" />
     <ClCompile Include="debug.cpp" />
     <ClCompile Include="directx_controller.cpp" />
+    <ClCompile Include="display.cpp" />
     <ClCompile Include="enemy.cpp" />
     <ClCompile Include="enemy_dynamic.cpp" />
     <ClCompile Include="enemy_static.cpp" />
@@ -169,6 +170,7 @@
     <ClInclude Include="contactlist.h" />
     <ClInclude Include="create_filter.h" />
     <ClInclude Include="debug.h" />
+    <ClInclude Include="display.h" />
     <ClInclude Include="DirectXTex.h" />
     <ClInclude Include="directx_controller.h" />
     <ClInclude Include="enemy.h" />

--- a/DX21_PuzzleGame.vcxproj.filters
+++ b/DX21_PuzzleGame.vcxproj.filters
@@ -94,6 +94,9 @@
     <ClCompile Include="create_filter.cpp">
       <Filter>ソースファイル</Filter>
     </ClCompile>
+    <ClCompile Include="display.cpp">
+      <Filter>ソースファイル</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="enemy.h">
@@ -199,6 +202,9 @@
       <Filter>ヘッダーファイル\object</Filter>
     </ClInclude>
     <ClInclude Include="create_filter.h">
+      <Filter>ヘッダーファイル</Filter>
+    </ClInclude>
+    <ClInclude Include="display.h">
       <Filter>ヘッダーファイル</Filter>
     </ClInclude>
   </ItemGroup>

--- a/UI_StaminaSpirit_Gauge.cpp
+++ b/UI_StaminaSpirit_Gauge.cpp
@@ -121,7 +121,7 @@ void	StaminaSpiritGauge::Draw()
 		}
 
 		//•`‰æ
-		DrawSprite(
+		DrawSpriteOld(
 			{ temp_position.x,
 			  temp_position.y },
 			0.0f,

--- a/anchor.cpp
+++ b/anchor.cpp
@@ -147,8 +147,6 @@ void Anchor::CreateAnchorBody(b2Vec2 anchor_size)
 	body.userData.pointer = (uintptr_t)this;
 
 
-
-
 	Box2dWorld& box2d_world = Box2dWorld::GetInstance();
 	b2World* world = box2d_world.GetBox2dWorldPointer();
 
@@ -158,12 +156,9 @@ void Anchor::CreateAnchorBody(b2Vec2 anchor_size)
 
 	player_body = m_body;//プレイヤーのボディをセット
 
-	
 
 
 	SetSize(anchor_size);//プレイヤー表示をするためにセットする
-
-
 
 
 

--- a/display.cpp
+++ b/display.cpp
@@ -9,10 +9,11 @@
 
 #include"display.h"
 #include"keyboard.h"
+#include"anchor_spirit.h"
 
 // 静的メンバ変数の定義（1回だけ行う）
 
-float display::m_display_scale = 0.5;//スケールの初期値の倍率
+float display::m_display_scale = 1;//スケールの初期値の倍率
 
 float display::m_display_width = 650;//横幅
 float display::m_display_height =300;//縦
@@ -47,6 +48,28 @@ void display::Update()
 	//{
 	//	SetDisplayWidth(+10);
 	//}
+
+
+	//-----------------------------------------------------------------------------------------------------------
+	//アンカーのレベルに応じた変更
+
+
+	if (AnchorSpirit::GetAnchorLevel() == 3)
+	{
+		if (GetDisplayScale() >= 0.5)
+		{
+			SetDisplayScale(-0.01);
+		}
+	}
+	else
+	{
+		if (GetDisplayScale() <= 1)
+		{
+			SetDisplayScale(0.01);
+		}
+	}
+
+	
 }
 
 //スケーリング

--- a/display.cpp
+++ b/display.cpp
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------------------------------------------------
+// #name display.cpp
+// #description 画面のスケールのを変更できる　と言っても　この中でするというよりは　スプライトの中でしてる
+// #make 2024/12/12　　永野義也
+// #update 2024/12/12
+// #comment 追加・修正予定
+//          ・特になし
+//----------------------------------------------------------------------------------------------------
+
+#include"display.h"
+#include"keyboard.h"
+
+// 静的メンバ変数の定義（1回だけ行う）
+
+float display::m_display_scale = 0.5;//スケールの初期値の倍率
+
+float display::m_display_width = 650;//横幅
+float display::m_display_height =300;//縦
+
+
+display::display()
+{
+}
+
+display::~display()
+{
+}
+
+void display::Update()
+{
+	//デバック用
+
+	//if (Keyboard_IsKeyDown(KK_D0))
+	//{
+	//	SetDisplayScale(-0.1f);
+	//}
+	//if (Keyboard_IsKeyDown(KK_D9))
+	//{
+	//	SetDisplayScale(+0.1);
+	//}
+
+	//if (Keyboard_IsKeyDown(KK_D8))
+	//{
+	//	SetDisplayWidth(-10);
+	//}
+	//if (Keyboard_IsKeyDown(KK_D7))
+	//{
+	//	SetDisplayWidth(+10);
+	//}
+}
+
+//スケーリング
+float display::GetDisplayScale()
+{
+	return m_display_scale;
+}
+void display::SetDisplayScale(float scale)
+{
+	m_display_scale = m_display_scale + scale;
+}
+
+//マップの横
+float display::GetDisplayWidth()
+{
+	return m_display_width;
+}
+void display::SetDisplayWidth(float width)
+{
+	m_display_width = m_display_width + width;
+}
+
+//マップの縦
+float display::GetDisplayHeight()
+{
+	return m_display_height;
+}
+void display::SetDisplayHeight(float height)
+{
+	m_display_height = m_display_height + height;
+}

--- a/display.h
+++ b/display.h
@@ -1,0 +1,45 @@
+//-----------------------------------------------------------------------------------------------------
+// #name display.h
+// #description 画面のスケールのを変更できる　と言っても　この中でするというよりは　スプライトの中でしてる
+// #make 2024/12/12　　永野義也
+// #update 2024/12/12
+// #comment 追加・修正予定
+//          ・特になし
+//----------------------------------------------------------------------------------------------------
+
+#ifndef DESPLAYE_H
+#define DESPLAYE_H
+
+class display
+{
+public:
+	display();
+	~display();
+
+	
+	static void Update();
+
+	//スケーリング
+	static float GetDisplayScale();
+	
+	static void SetDisplayScale(float scale);
+
+
+	//マップの横
+	static float GetDisplayWidth();
+
+	static void SetDisplayWidth(float width);
+
+	//マップの縦
+	static float GetDisplayHeight();
+
+	static void SetDisplayHeight(float height);
+
+private:
+	static float m_display_scale;
+	static float m_display_width;
+	static float m_display_height;
+};
+
+
+#endif // !DESPLAYE_H

--- a/game.cpp
+++ b/game.cpp
@@ -21,7 +21,7 @@
 #include"anchor.h"
 #include"word.h"
 #include"debug.h"
-
+#include"display.h"
 
 
 
@@ -115,6 +115,8 @@ void Game::Update(void)
 	// Box2D ワールドのステップ更新
 	b2World* world = Box2dWorld::GetInstance().GetBox2dWorldPointer();
 	world->Step(1.0f / 60.0f, 6, 2);
+
+	display::Update();
 
 	//プレイヤーの更新処理
 	player.Update();

--- a/sprite.cpp
+++ b/sprite.cpp
@@ -12,6 +12,7 @@
 
 #include "sprite.h"
 #include "keyboard.h"
+#include"display.h"
 
 //マクロ定義
 #define NUM_VERTEX 4
@@ -102,11 +103,68 @@ void DrawSprite(XMFLOAT2 Position, float Rotation, XMFLOAT2 Scale, float Alpha)
 	SetViewMatrix(view);
 
 	//移動・回転マトリクス設定
+	XMMATRIX world, rot, trans, scale,box2d_scale,box2d_trans;
+	scale = XMMatrixScaling(Scale.x, Scale.y, 0.0f);
+	rot = XMMatrixRotationZ(Rotation);
+	trans = XMMatrixTranslation(Position.x, Position.y, 0.0f);
+
+	//今回加えるスケール調整を追加している
+	box2d_scale = XMMatrixScaling(display::GetDisplayScale(), display::GetDisplayScale(), 0.0f);
+
+	//横軸の調整
+	box2d_trans= XMMatrixTranslation(display::GetDisplayWidth(),display::GetDisplayHeight() , 0.0f);
+
+	
+
+	world = scale * rot * trans*box2d_scale*box2d_trans;
+	SetWorldMatrix(world);
+
+	//プリミティブトポロジ設定
+	GetDeviceContext()->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+
+	//マテリアル設定（半年後に現れる）
+	MATERIAL material;
+	ZeroMemory(&material, sizeof(material));
+	material.Diffuse = XMFLOAT4(1.0f, 1.0f, 1.0f, Alpha);
+	SetMaterial(material);
+
+	g_Vertex[0].texcoord = XMFLOAT2(0.f, 0.f);
+	g_Vertex[1].texcoord = XMFLOAT2(1.f, 0.f);
+	g_Vertex[2].texcoord = XMFLOAT2(0.f, 1.f);
+	g_Vertex[3].texcoord = XMFLOAT2(1.f, 1.f);
+
+	SetVertexSprite();
+
+	//ポリゴン描画
+	GetDeviceContext()->Draw(NUM_VERTEX, 0);
+}
+
+//描画処理
+void DrawSpriteOld(XMFLOAT2 Position, float Rotation, XMFLOAT2 Scale, float Alpha)
+{
+	//頂点バッファ設定
+	UINT stride = sizeof(VERTEX_3D);
+	UINT offset = 0;
+	GetDeviceContext()->IASetVertexBuffers(0, 1, &g_VertexBuffer, &stride, &offset);
+
+	//プロジェクションマトリクス設定
+	XMMATRIX projection;
+	projection = XMMatrixOrthographicOffCenterLH(0.0f, SCREEN_WIDTH, SCREEN_HEIGHT, 0.0f, 0.0f, 1.0f);
+	SetProjectionMatrix(projection);
+
+	//ビューマトリクス設定
+	XMMATRIX view;
+	view = XMMatrixIdentity();
+	SetViewMatrix(view);
+
+	//移動・回転マトリクス設定
 	XMMATRIX world, rot, trans, scale;
 	scale = XMMatrixScaling(Scale.x, Scale.y, 0.0f);
 	rot = XMMatrixRotationZ(Rotation);
 	trans = XMMatrixTranslation(Position.x, Position.y, 0.0f);
-	world = scale * rot * trans;
+
+
+	world = scale * rot * trans ;
 	SetWorldMatrix(world);
 
 	//プリミティブトポロジ設定

--- a/sprite.h
+++ b/sprite.h
@@ -23,7 +23,10 @@ void UninitSprite(void);
 
 //	一枚の画像のすべてを描画
 // (Alpha値はデフォルトで1.0、変更がなければ値を渡さなくてもいいよ)
-void DrawSprite(XMFLOAT2 Position, float Rotation, XMFLOAT2 Scale, float Alpha = 1.0f);
+void DrawSprite(XMFLOAT2 Position, float Rotation, XMFLOAT2 Scale, float Alpha = 1.0f);//Box２ｄように中身を変えている
+
+//上と基本的には同じだがスケールの調整が変更されていない旧型
+void DrawSpriteOld(XMFLOAT2 Position, float Rotation, XMFLOAT2 Scale, float Alpha = 1.0f);
 
 //	一枚の画像を分割して、その中の一つだけを描画
 //(Alpha値はデフォルトで1.0、変更がなければ値を渡さなくてもいいよ)

--- a/world_box2d.h
+++ b/world_box2d.h
@@ -14,8 +14,8 @@
 
 #define SCREEN_SCALE (32.f) //ワールドの描画に用いる定数　描画自体に倍率をかける　数値が高いほど寄りになる
 
-#define SCREEN_CENTER_X (600.0f)//プレイヤーを真ん中よりも少し右に表示するために利用している
-#define SCREEN_CENTER_Y (350.0f)
+#define SCREEN_CENTER_X (0)//プレイヤーを真ん中よりも少し右に表示するために利用している
+#define SCREEN_CENTER_Y (0)
 
 //Box2dないの単位調整え利用している
 //このBox2dの１の単位は１ｍなので１ｍ＊１ｍのブロックを制作するとでかすぎて、それを動かすために必要な力も膨大な物になる


### PR DESCRIPTION
displayのupdateの内部に　レベルに応じた画面の縮小拡大のコードを追加

fix　sprite.cpp Drawspriteを変えた関係で　
UI＿anchor＿sprit.cppの 
左上のアンカーのレベルを視覚的に表現しているUIの部分もUiなのに一緒に縮小拡大始めたんで
そこで仕様する関数を従来の変更を受けない　Drawspriteoldに変更した