### PR TITLE
future_enemy_management_RenTakahashi

### DIFF
--- a/contactlist.h
+++ b/contactlist.h
@@ -2,7 +2,7 @@
 // #name contactlist.h
 // #description 衝突時の処理を管理する
 // #make 2024/11/22　永野義也
-// #update 2024/11/22
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・衝突時や衝突終了じなどの処理を書き込む
 // 
@@ -202,31 +202,35 @@ public:
              
         }
 
-        //静的プレイヤーとエネミーの衝突
+        //プレイヤーと静的エネミーの衝突
         if ((objectA->collider_type == collider_enemy_static && objectB->collider_type == collider_player_body) ||
             (objectA->collider_type == collider_player_body && objectB->collider_type == collider_enemy_static))
         {
             if (objectA->collider_type == collider_enemy_static)
             {
-                EnemyStatic::CollisionPlayer(fixtureA->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
+                enemy_instance->CollisionPlayer();
             }
             else if (objectB->collider_type == collider_enemy_static)
             {
-                EnemyStatic::CollisionPlayer(fixtureB->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
+                enemy_instance->CollisionPlayer();
             }
         }
 
-        //動的プレイヤーとエネミーの衝突
+        //プレイヤーと動的エネミーの衝突
         if ((objectA->collider_type == collider_enemy_dynamic && objectB->collider_type == collider_player_body) ||
             (objectA->collider_type == collider_player_body && objectB->collider_type == collider_enemy_dynamic))
         {
             if (objectA->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::CollisionPlayer(fixtureA->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
+                enemy_instance->CollisionPlayer();
             }
             else if (objectB->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::CollisionPlayer(fixtureB->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
+                enemy_instance->CollisionPlayer();
             }
         }
 
@@ -237,29 +241,32 @@ public:
             if ((objectA->collider_type == collider_enemy_static) &&
                 (fixtureB->GetBody()->GetLinearVelocity() != b2Vec2(0.0, 0.0)))
             {
-                EnemyStatic::CollisionPulledObject(fixtureA->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
+                enemy_instance->CollisionPulledObject();
             }
             else if ((objectB->collider_type == collider_enemy_static) &&
                 (fixtureA->GetBody()->GetLinearVelocity() != b2Vec2(0.0, 0.0)))
             {
-                EnemyStatic::CollisionPulledObject(fixtureB->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
+                enemy_instance->CollisionPulledObject();
             }
         }
 
         //引っ張られている状態のオブジェクトと動的エネミーの衝突
         if (((objectA->collider_type == collider_enemy_dynamic && objectB->collider_type == collider_object) ||
-            (objectA->collider_type == collider_object && objectB->collider_type == collider_enemy_dynamic)) &&
-            (Anchor::GetAnchorState() == Pulling_state))
+            (objectA->collider_type == collider_object && objectB->collider_type == collider_enemy_dynamic)))
         {
-            if ((objectA->collider_type == collider_enemy_dynamic && Anchor::GetAnchorState) &&
+            if ((objectA->collider_type == collider_enemy_dynamic) &&
                 (fixtureB->GetBody()->GetLinearVelocity() != b2Vec2(0.0, 0.0)))
             {
-                EnemyDynamic::CollisionPulledObject(fixtureA->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
+                enemy_instance->CollisionPulledObject();
             }
-            else if ((objectB->collider_type == collider_enemy_dynamic && Anchor::GetAnchorState) &&
+            else if ((objectB->collider_type == collider_enemy_dynamic) &&
                 (fixtureA->GetBody()->GetLinearVelocity() != b2Vec2(0.0, 0.0)))
             {
-                EnemyDynamic::CollisionPulledObject(fixtureB->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
+                enemy_instance->CollisionPulledObject();
             }
         }
      
@@ -269,11 +276,14 @@ public:
         {
             if (objectA->collider_type == collider_enemy_static)
             {
-                EnemyStatic::InPlayerSensor(fixtureA->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
+                enemy_instance->InPlayerSensor();
+
             }
             else if (objectB->collider_type == collider_enemy_static)
             {
-                EnemyStatic::InPlayerSensor(fixtureB->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
+                enemy_instance->InPlayerSensor();
             }
         }
 
@@ -283,11 +293,13 @@ public:
         {
             if (objectA->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::InPlayerSensor(fixtureA->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
+                enemy_instance->InPlayerSensor();
             }
             else if (objectB->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::InPlayerSensor(fixtureB->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
+                enemy_instance->InPlayerSensor();
             }
         }
     }
@@ -295,7 +307,8 @@ public:
 //               衝突終了時
 //---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------//
     void EndContact(b2Contact* contact) override {
-        // 衝突したフィクスチャを取得
+        ObjectManager& object_manager = ObjectManager::GetInstance();
+
         // 衝突したフィクスチャを取得
         b2Fixture* fixtureA = contact->GetFixtureA();
         b2Fixture* fixtureB = contact->GetFixtureB();
@@ -353,11 +366,19 @@ public:
         {
             if (objectA->collider_type == collider_enemy_static)
             {
-                EnemyStatic::OutPlayerSensor(fixtureA->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
+                if (enemy_instance)
+                {
+                    enemy_instance->OutPlayerSensor();
+                }
             }
             else if (objectB->collider_type == collider_enemy_static)
             {
-                EnemyStatic::OutPlayerSensor(fixtureB->GetBody());
+                EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
+                if (enemy_instance)
+                {
+                    enemy_instance->OutPlayerSensor();
+                }
             }
         }
 
@@ -367,11 +388,13 @@ public:
         {
             if (objectA->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::OutPlayerSensor(fixtureA->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
+                enemy_instance->OutPlayerSensor();
             }
             else if (objectB->collider_type == collider_enemy_dynamic)
             {
-                EnemyDynamic::OutPlayerSensor(fixtureB->GetBody());
+                EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
+                enemy_instance->OutPlayerSensor();
             }
         }
     }

--- a/enemy.cpp
+++ b/enemy.cpp
@@ -2,7 +2,7 @@
 // #name enemy.h
 // #description 動的、静的エネミーの継承元、エネミークラスのcppファイル
 // #make 2024/11/19
-// #update 2024/11/29
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・プレイヤーとの衝突判定を追加予定
 //			・倒れてきたオブジェクトとの衝突判定を追加予定
@@ -17,3 +17,31 @@
 #include"sprite.h"
 #include"keyboard.h"
 #include<Windows.h>
+#include"player_stamina.h"
+#include"anchor_spirit.h"
+
+//エネミーがプレイヤーに触れた時の処理
+void Enemy::CollisionPlayer()
+{
+	PlayerStamina::EditPlayerStaminaValue(-GetDamage());
+	SetUse(false);
+}
+
+//エネミーが動いている状態のオブジェクトに触れた時の処理
+void Enemy::CollisionPulledObject()
+{
+	AnchorSpirit::EditAnchorSpiritValue(GetSoulgage());
+	SetUse(false);
+}
+
+//エネミーがセンサー内に入った時の処理
+void Enemy::InPlayerSensor()
+{
+	SetInScreen(true);
+}
+
+//エネミーがセンサー外に出た時の処理
+void Enemy::OutPlayerSensor()
+{
+	SetInScreen(false);
+}

--- a/enemy.h
+++ b/enemy.h
@@ -2,7 +2,7 @@
 // #name enemy.h
 // #description 動的、静的エネミーの継承元、エネミークラスのヘッダーファイル
 // #make 2024/11/19
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          
 //           
@@ -19,6 +19,14 @@
 class Enemy
 {
 private:
+	//オブジェクト固有ID
+	int m_id = -999;
+
+	//body
+	b2Body* m_body = nullptr;
+	//サイズ
+	b2Vec2 m_size = b2Vec2(0.0f, 0.0f);
+
 	//エネミーの体力
 	int m_life;
 	//エネミーが与えるダメージ
@@ -37,6 +45,33 @@ public:
 	Enemy(int life, int damage, int soulgage, int score, bool use, bool in_screen)
 		:m_life(life), m_damage(damage), m_soulgage(soulgage), m_score(score), m_use(use), m_in_screen(false) {}
 	virtual ~Enemy() = default;
+
+	int GetID()
+	{
+		return m_id;
+	}
+	void SetID(int id)
+	{
+		m_id = id;
+	}
+
+	b2Body* GetBody()
+	{
+		return m_body;
+	}
+	void SetBody(b2Body* body)
+	{
+		m_body = body;
+	}
+
+	b2Vec2 GetSize()
+	{
+		return m_size;
+	}
+	void SetSize(b2Vec2 size)
+	{
+		m_size = size;
+	}
 
 	int GetLife()
 	{
@@ -83,7 +118,19 @@ public:
 		m_in_screen = in_screen;
 	}
 
-	virtual void UpdateEnemy() = 0;
+	virtual void Initialize() = 0;
+	virtual void Finalize() = 0;
+	virtual void Update() = 0;
+	virtual void Draw() = 0;
+
+	//エネミーがプレイヤーに触れた時の処理
+	void CollisionPlayer();
+	//エネミーが動いている状態のオブジェクトに触れた時の処理
+	void CollisionPulledObject();
+	//エネミーがセンサー内に入った時の処理
+	void InPlayerSensor();
+	//エネミーがセンサー外に出た時の処理
+	void OutPlayerSensor();
 };
 
 #endif	//ENEMY_H

--- a/enemy_dynamic.h
+++ b/enemy_dynamic.h
@@ -2,7 +2,7 @@
 // #name enemyDynamic.h
 // #description 動的エネミー(プレイヤー追従)のヘッダーファイル
 // #make 2024/11/20
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・
 //           
@@ -21,26 +21,22 @@
 #define ENEMY_DYNAMIC_SOULGAGE (100)
 #define ENEMY_DYNAMIC_SCORE (200)
 
-class EnemyDynamic :public Enemy, public Field
+class EnemyDynamic :public Enemy
 {
 private:
 	float m_speed = 0.005f;
 public:
 	EnemyDynamic() = default;
-	EnemyDynamic(b2Vec2 position, b2Vec2 body_size, float angle, bool bFixed, bool is_sensor, FieldTexture texture);
+	EnemyDynamic(b2Vec2 position, b2Vec2 body_size, float angle);
 	~EnemyDynamic() = default;
 
-	static void Update();
-	virtual void UpdateEnemy();
-	//エネミーがプレイヤーに触れた時の処理
-	static void CollisionPlayer(b2Body* collision_enemy);
-	//エネミーが動いている状態のオブジェクトに触れた時の処理
-	static void CollisionPulledObject(b2Body* collision_enemy);
-	//エネミーがセンサー内に入った時の処理
-	static void InPlayerSensor(b2Body* collision_enemy);
-	//エネミーがセンサー外に出た時の処理
-	static void OutPlayerSensor(b2Body* collision_enemy);
-	static void Finalize();
+	void Initialize() override;
+	void Finalize() override;
+	void Update() override;
+	void Draw() override;
+
+	//移動
+	void Move();
 };
 
 #endif	//ENEMY_DYNAMIC_H

--- a/enemy_static.cpp
+++ b/enemy_static.cpp
@@ -2,7 +2,7 @@
 // #name enemy.h
 // #description 静的エネミーのcppファイル
 // #make 2024/11/19
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・
 //           
@@ -19,18 +19,15 @@
 #include"player_position.h"
 #include"contactlist.h"
 #include"anchor_spirit.h"
+#include"object_manager.h"
 
-EnemyStatic* g_p_enemies_static[ENEMY_MAX] = { nullptr };
+static ID3D11ShaderResourceView* g_EnemyStatic_Texture = NULL;	//静的エネミーのテクスチャ
 
-EnemyStatic::EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle, bool bFixed, bool is_sensor, FieldTexture texture)
+EnemyStatic::EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle)
 	:Enemy(ENEMY_STATIC_LIFE, ENEMY_STATIC_DAMAGE, ENEMY_STATIC_SOULGAGE, ENEMY_STATIC_SCORE, true, false)
 {
-	//テクスチャをセット
-	SetFieldTexture(texture);
-
-
 	b2BodyDef body;
-	body.type = b2_dynamicBody;							//静的なオブジェクトにするならture
+	body.type = b2_staticBody;							//静的なオブジェクトにするならture
 	body.position.Set(position.x, position.y);			//ポジションをセット
 	body.angle = angle;									//角度の定義
 	body.userData.pointer = (uintptr_t)this;			//userDataのポインタを定義 
@@ -40,7 +37,7 @@ EnemyStatic::EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle, bool bF
 	Box2dWorld& box2d_world = Box2dWorld::GetInstance();//ワールドのインスタンスを取得する
 	b2World* world = box2d_world.GetBox2dWorldPointer();//ワールドのポインタを持ってくる
 
-	SetFieldBody(world->CreateBody(&body));//Bodyをワールドに固定
+	SetBody(world->CreateBody(&body));//Bodyをワールドに固定
 
 
 	SetSize(body_size);//表示用にサイズをセットしとく、表示のときにGetSizeを呼び出す
@@ -63,121 +60,73 @@ EnemyStatic::EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle, bool bF
 	fixture.restitution = 0.0f;//反発係数
 	fixture.isSensor = false;  //センサーかどうか、trueならあたり判定は消える
 
-	b2Fixture* enemy_static_fixture = GetFieldBody()->CreateFixture(&fixture);//Bodyをにフィクスチャを登録する
+	b2Fixture* enemy_static_fixture = GetBody()->CreateFixture(&fixture);//Bodyをにフィクスチャを登録する
 
 	// カスタムデータを作成して設定
 	// 動的エネミーに値を登録
 	// 動的エネミーにユーザーデータを登録
 	ObjectData* data = new ObjectData{ collider_enemy_static };
 	enemy_static_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(data);
-
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (!g_p_enemies_static[i])
-		{
-			g_p_enemies_static[i] = this;
-			return;
-		}
-	}
+	data->object_name = Object_Enemy_Static;
+	int ID = data->GenerateID();
+	data->id = ID;
+	SetID(ID);
 }
 
-void EnemyStatic::Update()
+void EnemyStatic::Initialize()
 {
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (g_p_enemies_static[i])
-		{
-			if (g_p_enemies_static[i]->GetUse() && g_p_enemies_static[i]->GetInScreen())
-			{
-				g_p_enemies_static[i]->UpdateEnemy();
-			}
-			else if(!g_p_enemies_static[i]->GetUse())
-			{
-				//ワールドに登録したbodyの削除(追加予定)
-				Box2dWorld& box2d_world = Box2dWorld::GetInstance();
-				b2World* world = box2d_world.GetBox2dWorldPointer();
-				world->DestroyBody(g_p_enemies_static[i]->GetFieldBody());
-
-				Field::DeleteFieldObject(g_p_enemies_static[i]->GetFieldBody());
-				g_p_enemies_static[i] = nullptr;
-			}
-		}
-	}
-}
-
-void EnemyStatic::UpdateEnemy()
-{
-
-}
-
-void EnemyStatic::CollisionPlayer(b2Body* collision_enemy)
-{
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (g_p_enemies_static[i])
-		{
-			if (g_p_enemies_static[i]->GetFieldBody() == collision_enemy)
-			{
-				AnchorSpirit::EditAnchorSpiritValue(-50); //加算
-				g_p_enemies_static[i]->SetUse(false);
-				return;
-			}
-		}
-	}
-}
-
-void EnemyStatic::CollisionPulledObject(b2Body* collision_enemy)
-{
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (g_p_enemies_static[i])
-		{
-			if (g_p_enemies_static[i]->GetFieldBody() == collision_enemy)
-			{
-				AnchorSpirit::EditAnchorSpiritValue(50);
-				g_p_enemies_static[i]->SetUse(false);
-				return;
-			}
-		}
-	}
-}
-
-void EnemyStatic::InPlayerSensor(b2Body* collision_enemy)
-{
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (g_p_enemies_static[i])
-		{
-			if (g_p_enemies_static[i]->GetFieldBody() == collision_enemy)
-			{
-				g_p_enemies_static[i]->SetInScreen(true);
-				return;
-			}
-		}
-	}
-}
-void EnemyStatic::OutPlayerSensor(b2Body* collision_enemy)
-{
-	for (int i = 0; i < ENEMY_MAX; i++)
-	{
-		if (g_p_enemies_static[i])
-		{
-			if (g_p_enemies_static[i]->GetFieldBody() == collision_enemy)
-			{
-				g_p_enemies_static[i]->SetInScreen(false);
-				return;
-			}
-		}
-	}
+	g_EnemyStatic_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_block.png");//静的エネミーのテクスチャ
 }
 
 void EnemyStatic::Finalize()
 {
-	for (int i = 0; i < ENEMY_MAX; i++)
+	UnInitTexture(g_EnemyStatic_Texture);
+}
+
+void EnemyStatic::Update()
+{
+	if (GetUse() && GetInScreen())
 	{
-		if (g_p_enemies_static[i])
-		{
-			g_p_enemies_static[i] = nullptr;
-		}
+
 	}
+	else if (!GetUse())
+	{
+		//ワールドに登録したbodyの削除
+		Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+		b2World* world = box2d_world.GetBox2dWorldPointer();
+		world->DestroyBody(GetBody());
+
+		//オブジェクトマネージャー内のエネミー削除
+		ObjectManager& object_manager = ObjectManager::GetInstance();
+		object_manager.DestroyEnemyStatic(GetID());
+	}
+}
+
+void EnemyStatic::Draw()
+{
+	// スケールをかけないとオブジェクトのサイズの表示が小さいから使う
+	float scale = SCREEN_SCALE;
+
+	// スクリーン中央位置 (プロトタイプでは乗算だったけど　今回から加算にして）
+	b2Vec2 screen_center;
+	screen_center.x = SCREEN_CENTER_X;
+	screen_center.y = SCREEN_CENTER_Y;
+
+	b2Vec2 position = GetBody()->GetPosition();
+
+	// プレイヤー位置を考慮してスクロール補正を加える
+	//取得したbodyのポジションに対してBox2dスケールの補正を加える
+	float draw_x = ((position.x - PlayerPosition::GetPlayerPosition().x) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.x;
+	float draw_y = ((position.y - PlayerPosition::GetPlayerPosition().y) * BOX2D_SCALE_MANAGEMENT) * scale + screen_center.y;
+
+	//貼るテクスチャを指定
+	GetDeviceContext()->PSSetShaderResources(0, 1, &g_EnemyStatic_Texture);
+
+	//draw
+	DrawSprite(
+		{ draw_x,
+		  draw_y },
+		GetBody()->GetAngle(),
+		{ GetSize().x * scale , GetSize().y * scale }
+	);
 }

--- a/enemy_static.h
+++ b/enemy_static.h
@@ -2,7 +2,7 @@
 // #name enemy.h
 // #description 静的エネミーのヘッダーファイル
 // #make 2024/11/19
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・
 //           
@@ -21,26 +21,19 @@
 #define ENEMY_STATIC_SOULGAGE (100)
 #define ENEMY_STATIC_SCORE (100)
 
-class EnemyStatic :public Enemy, public Field
+class EnemyStatic :public Enemy
 {
 private:
 	
 public:
 	EnemyStatic() = default;
-	EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle, bool bFixed, bool is_sensor, FieldTexture texture);
-	~EnemyStatic() {  };
+	EnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle);
+	~EnemyStatic() = default;
 	
-	static void Update();
-	virtual void UpdateEnemy();
-	//エネミーがプレイヤーに触れた時の処理
-	static void CollisionPlayer(b2Body* collision_enemy);
-	//エネミーが動いている状態のオブジェクトに触れた時の処理
-	static void CollisionPulledObject(b2Body* collision_enemy);
-	//エネミーがセンサー内に入った時の処理
-	static void InPlayerSensor(b2Body* collision_enemy);
-	//エネミーがセンサー外に出た時の処理
-	static void OutPlayerSensor(b2Body* collision_enemy);
-	static void Finalize();
+	void Initialize() override;
+	void Finalize() override;
+	void Update() override;
+	void Draw() override;
 };
 
 #endif	//ENEMY_STATIC_H

--- a/field.cpp
+++ b/field.cpp
@@ -2,7 +2,7 @@
 // #name field.cpp
 // #description csvを用いてマップチップを作成し、描画するファイル
 // #make 2024/11/04　永野義也
-// #update 2024/12/01
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・Fieldの設定をしてる  呼び出しの仕方としてｈスコープ解決演算子使ってやって （Field::Draw)
 //			・マップを管理する基底クラスでグランドなどが継承している
@@ -43,8 +43,6 @@ ObjectManager& objectManager = ObjectManager::GetInstance();
 // 使用するテクスチャファイルを格納
 static ID3D11ShaderResourceView* g_Ground_Texture = NULL;//地面のテクスチャ
 static ID3D11ShaderResourceView* g_AnchorPoint_Texture = NULL;//アンカーポイントのテクスチャ
-static ID3D11ShaderResourceView* g_EnemyDynamic_Texture = NULL;	//動的エネミーのテクスチャ
-static ID3D11ShaderResourceView* g_EnemyStatic_Texture = NULL;	//静的エネミーのテクスチャ
 
 Field::Field()
 {
@@ -65,8 +63,6 @@ void Field::Initialize()
 	//テクスチャの初期化
 	g_Ground_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_green.png");//グラウンドのテクスチャ
 	g_AnchorPoint_Texture= InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_red.png");//アンカーポイントのテクスチャ
-	g_EnemyDynamic_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_yellow.png");//動的エネミーのテクスチャ
-	g_EnemyStatic_Texture = InitTexture(L"asset\\texture\\sample_texture\\img_sample_texture_block.png");//静的エネミーのテクスチャ
 
 	//APのイニシャライズ
 	AnchorPoint::Initialize();
@@ -112,10 +108,10 @@ void Field::Initialize()
 				m_p_field_array[y][x] = new Ground(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 1.0f), 0.0f, true, true, ground_texture);
 			}
 			if (field_map[y][x] == 5) {
-				m_p_field_array[y][x] = new EnemyStatic(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 1.0f), 0.0f, false, true, enemy_static_texture);
+				objectManager.AddEnemyStatic(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 1.0f), 0.0f);
 			}
 			if (field_map[y][x] == 6) {
-				m_p_field_array[y][x] = new EnemyDynamic(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 1.0f), 0.0f, true, true, enemy_dynamic_texture);
+				objectManager.AddEnemyDynamic(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 1.0f), 0.0f);
 			}
 			if (field_map[y][x] == 7) {
 				objectManager.AddWood(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(1.0f, 8.0f),b2Vec2(1.0f,1.0f),1);
@@ -179,8 +175,6 @@ void Field::Update()
 {
 	//アンカーポイントの更新
 	AnchorPoint::Update();
-	EnemyDynamic::Update();
-	EnemyStatic::Update();
 
 	objectManager.UpdateAll();
 }
@@ -218,12 +212,6 @@ void Field::Draw()
 					break;
 				case ground_texture:
 					GetDeviceContext()->PSSetShaderResources(0, 1, &g_Ground_Texture);
-					break;
-				case enemy_dynamic_texture:
-					GetDeviceContext()->PSSetShaderResources(0, 1, &g_EnemyDynamic_Texture);
-					break;
-				case enemy_static_texture:
-					GetDeviceContext()->PSSetShaderResources(0, 1, &g_EnemyStatic_Texture);
 					break;
 				default:
 					break;
@@ -271,9 +259,6 @@ void Field::Finalize()
 	}
 	delete[] m_p_field_array;
 	m_p_field_array = nullptr;
-  
-	EnemyDynamic::Finalize();
-	EnemyStatic::Finalize();
 }
 
 

--- a/object_manager.cpp
+++ b/object_manager.cpp
@@ -2,7 +2,7 @@
 // #name object_manager.cpp
 // #description オブジェクトの管理をするCPP　
 // #make 2024/12/04　永野義也
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・噂のファクトリーってやつかもねー
 //          ・これのインスタンスの管理いいなー　がち綺麗
@@ -47,6 +47,17 @@ void ObjectManager::AddSloping_block(const b2Vec2& position, const b2Vec2& size,
 void ObjectManager::AddStatic_to_Dynamic_block(const b2Vec2& position, const b2Vec2& size, const collider_type_Box_or_Circle& collider_type, const int& need_level) {
     // 既存の 3 引数コンストラクタを利用して生成
     static_to_dynamic_blockList.emplace_back(std::make_unique<static_to_dynamic_block>(position,size,collider_type,need_level));
+}
+
+//静的エネミー生成
+void ObjectManager::AddEnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle)
+{
+    enemy_staticList.emplace_back(std::make_unique<EnemyStatic>(position, body_size, angle));
+}
+//動的エネミー生成
+void ObjectManager::AddEnemyDynamic(b2Vec2 position, b2Vec2 body_size, float angle)
+{
+    enemy_dynamicList.emplace_back(std::make_unique<EnemyDynamic>(position, body_size, angle));
 }
 
 
@@ -101,6 +112,51 @@ static_to_dynamic_block* ObjectManager::FindStatic_to_Dynamic_BlcokID(int id) {
     return nullptr; // 見つからない場合は nullptr を返す
 }
 
+//IDを使って静的エネミーを検索
+EnemyStatic* ObjectManager::FindEnemyStaticByID(int id)
+{
+    for (auto& w : enemy_staticList) {
+        if (w->GetID() == id) {
+            return w.get();
+        }
+    }
+    return nullptr; // 見つからない場合は nullptr を返す
+}
+//IDを使って動的エネミーを検索
+EnemyDynamic* ObjectManager::FindEnemyDynamicByID(int id)
+{
+    for (auto& w : enemy_dynamicList) {
+        if (w->GetID() == id) {
+            return w.get();
+        }
+    }
+    return nullptr; // 見つからない場合は nullptr を返す
+}
+
+//指定の静的エネミーを削除
+void ObjectManager::DestroyEnemyStatic(int id)
+{
+    int cnt = 0;
+    for (auto& w : enemy_staticList) {
+        if (w->GetID() == id) {
+            enemy_staticList.erase(enemy_staticList.begin() + cnt);
+            break;
+        }
+        ++cnt;
+    }
+}
+//指定の動的エネミーを削除
+void ObjectManager::DestroyEnemyDynamic(int id)
+{
+    int cnt = 0;
+    for (auto& w : enemy_dynamicList) {
+        if (w->GetID() == id) {
+            enemy_dynamicList.erase(enemy_dynamicList.begin() + cnt);
+            break;
+        }
+        ++cnt;
+    }
+}
 
 // 全ての木を初期化
 void ObjectManager::InitializeAll() {
@@ -122,6 +178,14 @@ void ObjectManager::InitializeAll() {
     }
 
     for (auto& w : static_to_dynamic_blockList) {
+        w->Initialize();
+    }
+
+    for (auto& w : enemy_staticList) {
+        w->Initialize();
+    }
+
+    for (auto& w : enemy_dynamicList) {
         w->Initialize();
     }
 }
@@ -148,6 +212,20 @@ void ObjectManager::UpdateAll() {
     for (auto& w : static_to_dynamic_blockList) {
         w->Update();
     }
+
+    for (auto& w : enemy_staticList) {
+        if(w)
+        {
+            w->Update();
+        }
+    }
+
+    for (auto& w : enemy_dynamicList) {
+        if(w)
+        {
+            w->Update();
+        }
+    }
 }
 
 // 全ての木を描画
@@ -169,6 +247,14 @@ void ObjectManager::DrawAll() {
     }
 
     for (auto& w : static_to_dynamic_blockList) {
+        w->Draw();
+    }
+
+    for (auto& w : enemy_staticList) {
+        w->Draw();
+    }
+
+    for (auto& w : enemy_dynamicList) {
         w->Draw();
     }
 }
@@ -193,12 +279,19 @@ void ObjectManager::FinalizeAll() {
         w->Finalize();
     }
 
+    for (auto& w : enemy_staticList) {
+        w->Finalize();
+    }
+
 
     woodList.clear(); // 動的配列をクリアしてメモリ解放
     rockList.clear();
     one_way_platformList.clear();
     sloping_blockList.clear();
     static_to_dynamic_blockList.clear();
+    enemy_staticList.clear();
+    enemy_dynamicList.clear();
+
 }
 
 

--- a/object_manager.h
+++ b/object_manager.h
@@ -2,7 +2,7 @@
 // #name object_manager
 // #description オブジェクトを管理するためのファクトリーのイメージに近い
 // #make 2024/12/04　永野義也
-// #update 2024/12/04
+// #update 2024/12/13
 // #comment 追加・修正予定
 //          ・オブジェクトを作るごとに生成する感じ
 //----------------------------------------------------------------------------------------------------
@@ -18,6 +18,8 @@
 #include"sloping_block.h"
 #include"rock.h"
 #include"static_to_dynamic_block.h"
+#include"enemy_static.h"
+#include"enemy_dynamic.h"
 
 // オブジェクトの種類を定義
 enum ObjectType {
@@ -25,9 +27,10 @@ enum ObjectType {
     Object_Wood, // 木
     Object_Rock, // 岩
     Object_one_way_platform,//足場　したからしか乗れない
-    Object_Static_to_Dynamic//静的から動的に変更するオブジェクト
+    Object_Static_to_Dynamic,//静的から動的に変更するオブジェクト
     
-
+    Object_Enemy_Static,//静的エネミー
+    Object_Enemy_Dynamic,//動的エネミー
 };
 
 
@@ -48,6 +51,10 @@ public:
     void AddSloping_block(const b2Vec2& position, const b2Vec2& size, const SlopingBlockAspect& aspect);
     //静的→動的のブロックの追加
     void AddStatic_to_Dynamic_block(const b2Vec2& position, const b2Vec2& size, const collider_type_Box_or_Circle& collider_type, const int& need_level);
+    //静的エネミー生成
+    void AddEnemyStatic(b2Vec2 position, b2Vec2 body_size, float angle);
+    //動的エネミー生成
+    void AddEnemyDynamic(b2Vec2 position, b2Vec2 body_size, float angle);
 
     // ID を使って木を検索
     wood* FindWoodByID(int id);
@@ -59,6 +66,15 @@ public:
     sloping_block* FindSloping_BlockByID(int id);
     //IDを使って静的→動的ブロックを追加
     static_to_dynamic_block* FindStatic_to_Dynamic_BlcokID(int id);
+    //IDを使って静的エネミーを検索
+    EnemyStatic* FindEnemyStaticByID(int id);
+    //IDを使って動的エネミーを検索
+    EnemyDynamic* FindEnemyDynamicByID(int id);
+
+    //指定の静的エネミーを削除
+    void DestroyEnemyStatic(int id);
+    //指定の動的エネミーを削除
+    void DestroyEnemyDynamic(int id);
 
 
     // 全てのオブジェクトを初期化
@@ -79,9 +95,10 @@ private:
     std::vector<std::unique_ptr<one_way_platform>> one_way_platformList;// 足場のリスト
     std::vector<std::unique_ptr<sloping_block>> sloping_blockList;//斜面のリスト
     std::vector<std::unique_ptr<static_to_dynamic_block>> static_to_dynamic_blockList;//静的→動的ブロック挙動
-    
+    std::vector<std::unique_ptr<EnemyStatic>> enemy_staticList;//静的エネミーのリスト
+    std::vector<std::unique_ptr<EnemyDynamic>> enemy_dynamicList;//静的エネミーのリスト
 
-    //ここにオブジェクトごとにリストを追加していく感じだねぇー
+    //ここにオブジェクトごとにリストを追加していく感じ
 
 
     ObjectManager() = default;


### PR DESCRIPTION
追加、更新
・オブジェクトマネージャーからエネミーを管理するように変更しました。object_managerに動的、静的エネミー用の関数(追加、検索、特定のエネミーの削除)の追加や既存の関数内への追加などがあります。また、管理方法の変化に伴い、contactlist内の処理にも変更があります 
・fieldでのエネミーの管理の終了に伴いfield内の処理の変更があります。また、動的、静的エネミーのbodyやsize、衝突判定の関数などをenemy基底クラスで作成、管理するように変更しました 
・動的エネミーの動作を調整しました
追加予定
・動的エネミーの攻撃