### PR TITLE
追加：scene_manager

### DIFF
--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -151,6 +151,8 @@
     <ClCompile Include="player_stamina.cpp" />
     <ClCompile Include="renderer.cpp" />
     <ClCompile Include="rock.cpp" />
+    <ClCompile Include="scene_manager_Instance.cpp" />
+    <ClCompile Include="scene_manager_instance.h" />
     <ClCompile Include="sloping_block.cpp" />
     <ClCompile Include="sound.cpp" />
     <ClCompile Include="sprite.cpp" />
@@ -188,6 +190,7 @@
     <ClInclude Include="player_stamina.h" />
     <ClInclude Include="renderer.h" />
     <ClInclude Include="rock.h" />
+    <ClInclude Include="scene.h" />
     <ClInclude Include="sloping_block.h" />
     <ClInclude Include="sound.h" />
     <ClInclude Include="sprite.h" />

--- a/game.cpp
+++ b/game.cpp
@@ -24,23 +24,11 @@
 #include"display.h"
 
 
-
-HRESULT Game::Initialize(HINSTANCE hInstance, HWND hWnd, BOOL bWindow)
+void Game::Initialize()
 {
-	//レンダリング処理の初期化
-	InitRenderer(hInstance, hWnd, bWindow);
-
-	//サウンドの初期化
-	InitSound(hWnd);
-
-	//ポリゴン
-	InitSprite();
 
 	//文字（絵）
 	InitializeWord();
-
-	//コントローラーの初期化
-	controller.Initialize(hInstance,hWnd);
 
 	//プレイヤーの初期化
 	player.Initialize();
@@ -66,7 +54,7 @@ HRESULT Game::Initialize(HINSTANCE hInstance, HWND hWnd, BOOL bWindow)
 	InitializeDebug();
 #endif // !_DEBUG
 
-	return S_OK;
+	
 }
 
 void Game::Finalize(void)
@@ -74,8 +62,7 @@ void Game::Finalize(void)
 	//ポリゴン
 	UninitSprite();
 
-	//コントローラーの終了処理
-	controller.Release();
+	
 
 	//サウンドの終了処理
 	UninitSound();
@@ -127,7 +114,7 @@ void Game::Update(void)
 	//フィールドの更新処理
 	Field::Update();
 
-	controller.CheckInput();
+
 
 
 #ifdef _DEBUG

--- a/game.h
+++ b/game.h
@@ -34,13 +34,13 @@ public:
 
 
 
-	HRESULT Initialize(HINSTANCE hInstance, HWND hWnd, BOOL bWindow);
+	void Initialize();
 	void Update();
 	void Draw();
 	void Finalize();
 
 private:
-	DirectInputController controller;
+	
 	Player player;
 	StaminaSpiritGauge stamina_spirit_gauge;
 	

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@
 #include "keyboard.h"
 #include "sound.h"
 #include"game.h"
+#include"scene.h"
 
 
 
@@ -92,10 +93,21 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	}
 
 	//DirectXの初期化（ウィンドウを作成した後に行う）
-	if (FAILED(game.Initialize(hInstance, hWnd, true)))
-	{
-		return -1;
-	}
+	
+		//レンダリング処理の初期化
+	InitRenderer(hInstance, hWnd, true);
+
+	//サウンドの初期化
+	InitSound(hWnd);
+
+	//ポリゴン
+	InitSprite();
+
+		
+
+		
+
+	
 
 	//時間計測用
 	DWORD dwExecLastTime;
@@ -114,6 +126,15 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 	//メッセージループ
 	MSG    msg;
+
+	//シーンの管理
+	SceneManager scene_manager;
+	scene_manager.RegisterScene(1, []() { return std::make_unique<MenuScene>(); });
+	scene_manager.RegisterScene(2, []() { return std::make_unique<GameScene>(); });
+
+	//初期シーンの設定
+	scene_manager.ChangeScene(2);
+	
 
 	while (1)
 	{
@@ -154,8 +175,11 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			{
 				dwExecLastTime = dwCurrentTime;
 
-				game.Update();
-				game.Draw();
+			
+
+				scene_manager.Update();
+
+				scene_manager.Draw();
 
 				dwFrameCount++;
 			}

--- a/main.h
+++ b/main.h
@@ -27,6 +27,7 @@
 #include "dinput.h"
 #include "mmsystem.h"
 
+
 #pragma warning(pop)
 
 

--- a/scene.h
+++ b/scene.h
@@ -1,0 +1,120 @@
+#ifndef SCENE_H
+#define SCENE_H
+
+#include <iostream>
+#include <unordered_map>
+#include <functional>
+#include <memory>
+#include"game.h"
+
+// シーン基底クラス
+class Scene {
+public:
+    virtual ~Scene() = default;
+    // 初期化処理
+    virtual void Initialize() {}
+
+    // 更新処理
+    virtual void Update() = 0;
+
+    //描画処理
+    virtual void Draw() = 0;
+
+    // 終了処理
+    virtual void Finalize() {}
+   
+};
+
+class MenuScene : public Scene {
+public:
+    void Initialize() override {
+        std::cout << "Menu Scene Initialized" << std::endl;
+    }
+
+    void Update() override {
+        std::cout << "Menu Scene Updating" << std::endl;
+    }
+
+    void Draw()override
+    {
+        std::cout << "Menu Scene Drawing" << std::endl;
+    }
+
+    void Finalize() override {
+        std::cout << "Menu Scene Finalized" << std::endl;
+    }
+};
+
+class GameScene : public Scene {
+public:
+
+    Game& game = Game::GetInstance();
+    void Initialize() override {
+        std::cout << "Game Scene Initialized" << std::endl;
+
+        game.Initialize();
+    }
+
+    void Update() override {
+        std::cout << "Game Scene Updating" << std::endl;
+        game.Update();
+    }
+
+    void Draw()override
+    {
+        std::cout << "Game Scene Drawing" << std::endl;
+        game.Draw();
+    }
+
+    void Finalize() override {
+        std::cout << "Game Scene Finalized" << std::endl;
+        game.Finalize();
+    }
+};
+
+// シーン管理クラス
+class SceneManager {
+private:
+    std::unordered_map<int, std::function<std::unique_ptr<Scene>()>> sceneRegistry;
+    std::unique_ptr<Scene> currentScene;
+
+public:
+    // シーンの登録
+    void RegisterScene(int id, std::function<std::unique_ptr<Scene>()> factory) {
+        sceneRegistry[id] = factory;
+    }
+
+    // シーンの切り替え
+    void ChangeScene(int id) {
+        // 現在のシーンの終了処理を実行
+        if (currentScene) {
+            currentScene->Finalize();
+        }
+
+        // 新しいシーンを生成
+        auto it = sceneRegistry.find(id);
+        if (it != sceneRegistry.end()) {
+            currentScene = it->second();
+            currentScene->Initialize();
+        }
+    }
+
+    // 更新処理
+    void Update() {
+        if (currentScene) {
+            currentScene->Update();
+        }
+    }
+
+    //描画処理
+    void Draw()
+    {
+        if (currentScene)
+        {
+            currentScene->Draw();
+        }
+    }
+};
+
+#endif // !SCENE_H
+

--- a/scene_manager_Instance.cpp
+++ b/scene_manager_Instance.cpp
@@ -1,0 +1,4 @@
+#include"scene_manager_instance.h"
+
+//グローバルインスタンスの定義
+SceneManager g_SceneManager;

--- a/scene_manager_instance.h
+++ b/scene_manager_instance.h
@@ -1,0 +1,7 @@
+#ifndef SCENE_MANAGER_INSTANCE_H
+#define SCENE_MANAGER_INSTANCE_H
+#include"scene.h"
+
+extern SceneManager g_SceneManager;
+
+#endif // !SCENE_MANAGER_INSTANCE_H


### PR DESCRIPTION
シーンを変更するするマネージャーを追加

及びmain.cppの中身を変更

すべてのシーンで必要となる初期化について直接mainに書き込むように変更

コードの確認のため、現在の初期シーンはgameにしている。

game.cppの
イニシャライズの中身を変更、前までは、Drawなどのスプライトの初期化などもいれていたが
それをmainに移動した
