### PR TITLE
修正：シーン遷移のバグの修正

### DIFF
--- a/anchor_point.cpp
+++ b/anchor_point.cpp
@@ -277,7 +277,14 @@ void AnchorPoint::Finalize()
 
 	if (g_select_anchor_point_body != nullptr)
 	{
-		world->DestroyBody(g_select_anchor_point_body);
+		if (Player::GetOutSidePlayerBody() != g_select_anchor_point_body)
+		{
+			world->DestroyBody(g_select_anchor_point_body);
+		}
+		else
+		{
+			g_select_anchor_point_body = nullptr;
+		}
 	}
 
 	//テクスチャの解放

--- a/enemy_dynamic.cpp
+++ b/enemy_dynamic.cpp
@@ -80,6 +80,16 @@ void EnemyDynamic::Initialize()
 
 void EnemyDynamic::Finalize()
 {
+
+	//ワールドのインスタンスを持ってくる
+	Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+	b2World* world = box2d_world.GetBox2dWorldPointer();
+
+
+	if (GetBody() != nullptr)
+	{
+		world->DestroyBody(GetBody());
+	}
 	UnInitTexture(g_EnemyDynamic_Texture);
 }
 

--- a/enemy_static.cpp
+++ b/enemy_static.cpp
@@ -80,6 +80,17 @@ void EnemyStatic::Initialize()
 
 void EnemyStatic::Finalize()
 {
+
+	//ワールドのインスタンスを持ってくる
+	Box2dWorld& box2d_world = Box2dWorld::GetInstance();
+	b2World* world = box2d_world.GetBox2dWorldPointer();
+
+
+	if (GetBody() != nullptr)
+	{
+		world->DestroyBody(GetBody());
+	}
+
 	UnInitTexture(g_EnemyStatic_Texture);
 }
 


### PR DESCRIPTION
アンカーポイントをしていしない状態でシーン遷移出来ないバグの修正と

エネミー自体のボディを削除していないことによるNULLエラーの解消のため
エネミーのファイナライズにボディを削除を追加