### PR TITLE
更新：mainのsoundに関する関数宣言を無効化

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -225,8 +225,9 @@ HRESULT FirstInit(HINSTANCE hInstance, HWND hWnd, BOOL bWindow)
 	//レンダリング処理の初期化
 	InitRenderer(hInstance, hWnd, bWindow);
 
+	//2024/12/27 CRIに移行する関係で、一度コメントアウトで無効化
 	//サウンドの初期化
-	InitSound(hWnd);
+	//InitSound(hWnd);
 
 	//ポリゴン
 	InitSprite();
@@ -239,8 +240,9 @@ void FinalFinalize()
 	//ポリゴン
 	UninitSprite();
 
+	//2024/12/27 CRIに移行する関係で、一度コメントアウトで無効化
 	//サウンドの終了処理
-	UninitSound();
+	//UninitSound();
 
 	//レンダリングの終了処理
 	UninitRenderer();


### PR DESCRIPTION
soundをCRIに変更する関係で、main内のsoundのinitializeとfinalizeを一度コメントアウトで無効化