### PR TITLE
feature_Spirit_Bug_wong

### DIFF
--- a/Item_Spirit.cpp
+++ b/Item_Spirit.cpp
@@ -96,13 +96,16 @@ void	ItemSpirit::Update()
             vec.y = player_position.y - m_body->GetPosition().y;
             vec.Normalize();
 
-            float speed = 0.2f;
+            float speed = 0.5f;
 
             GetBody()->ApplyLinearImpulseToCenter(b2Vec2(vec.x * speed, vec.y * speed), true);
 
             //ソウルのサイズが徐々に減る
-            m_size.x -= 0.005f;
-            m_size.y -= 0.005f;
+            if (m_size.x > 0.8f || m_size.y > m_size.x * 2)
+            {
+                m_size.x -= 0.005f;
+                m_size.y -= 0.005f;
+            }
 
         }
         //状態が上昇中の場合

--- a/contactlist.h
+++ b/contactlist.h
@@ -415,13 +415,16 @@ public:
             if (objectA->collider_type == collider_enemy_static)
             {
                 EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
-                enemy_instance->InPlayerSensor();
-
+                if (enemy_instance != nullptr) {
+                    enemy_instance->InPlayerSensor();
+                }
             }
             else if (objectB->collider_type == collider_enemy_static)
             {
                 EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
-                enemy_instance->InPlayerSensor();
+                if (enemy_instance != nullptr) {
+                    enemy_instance->InPlayerSensor();
+                }
             }
         }
 
@@ -432,12 +435,14 @@ public:
             if (objectA->collider_type == collider_enemy_dynamic)
             {
                 EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
-                enemy_instance->InPlayerSensor();
+                if (enemy_instance != nullptr)
+                    enemy_instance->InPlayerSensor();
             }
             else if (objectB->collider_type == collider_enemy_dynamic)
             {
                 EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
-                enemy_instance->InPlayerSensor();
+                if (enemy_instance != nullptr)
+                    enemy_instance->InPlayerSensor();
             }
         }
 
@@ -466,7 +471,9 @@ public:
                 object_fixture = fixtureB;
             }
             ItemSpirit* spirit_instance = item_manager.FindItem_Spirit_ByID(spirit_data->id);//ItemSpeedUpで同じIDのを探してインスタンスをもらう
-           
+            if (spirit_instance == nullptr) {
+                return;
+            }
             // もし収集中の場合は衝突処理を無視
             //-------------------------------------------------------------------------
             if (spirit_instance->GetState() == Spirit_Collecting)
@@ -524,24 +531,29 @@ public:
             case ITEM_SPEED_UP:
             {
                 ItemSpeedUp* item_instance = item_manager.FindItem_SpeedUp_ByID(item->id);//ItemSpeedUpで同じIDのを探してインスタンスをもらう
-                item_instance->Function();
-                item_instance->SetDestory(true);//削除を呼び出す
+                if (item_instance != nullptr) {
+                    item_instance->Function();
+                    item_instance->SetDestory(true);//削除を呼び出す
+                }
             }
             break;
             case ITEM_SPIRIT:
             {
                 ItemSpirit* spirit_instance = item_manager.FindItem_Spirit_ByID(item->id);//ItemSpeedUpで同じIDのを探してインスタンスをもらう
-                //spirit_instance->SetIfCollidedPlayer(true);
-                spirit_instance->Function();
-                spirit_instance->SetState(Spirit_Destory);//削除を呼び出す
+                if (spirit_instance != nullptr) {
+                    spirit_instance->Function();
+                    spirit_instance->SetState(Spirit_Destory);//削除を呼び出す
+                }
 
             }
             break;
             case ITEM_COIN:
             {
                 ItemCoin* coin_instance = item_manager.FindItem_Coin_ByID(item->id);//ItemSpeedUpで同じIDのを探してインスタンスをもらう
-                coin_instance->Function();
-                coin_instance->SetDestory(true);//削除を呼び出す
+                if (coin_instance != nullptr) {
+                    coin_instance->Function();
+                    coin_instance->SetDestory(true);//削除を呼び出す
+                }
             }
             break;
 
@@ -588,14 +600,18 @@ public:
             if (objectA->object_name == Object_Movable_Ground)//Aが岩のオブジェクト
             {
                 movable_ground* ground_instance = object_manager.FindMovable_GroundID(objectA->id);//movable_groundで同じIDのを探してインスタンスをもらう
-                ground_instance->SetIfPulling(false);
+                if (ground_instance != nullptr) {
+                    ground_instance->SetIfPulling(false);
+                }
             }
             else
             {
                 movable_ground* ground_instance = object_manager.FindMovable_GroundID(objectB->id);//movable_groundで同じIDのを探してインスタンスをもらう
-                ground_instance->SetIfPulling(false);
-            }
+                if (ground_instance != nullptr) {
+                    ground_instance->SetIfPulling(false);
 
+                }
+            }
         }        
         //引っ張れる床と敵が離れた場合
         if ((objectA->collider_type == collider_enemy_static && objectB->collider_type == collider_object_destroyer_of_enemy) ||
@@ -606,13 +622,17 @@ public:
             {
                 movable_ground* ground_instance = object_manager.FindMovable_GroundID(objectB->id);//movable_groundで同じIDのを探してインスタンスをもらう
                 EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectA->id);
-                ground_instance->DeleteContactedEnemyList(enemy_instance);
+                if (enemy_instance != nullptr && ground_instance != nullptr) {
+                    ground_instance->DeleteContactedEnemyList(enemy_instance);
+                }
             }
             else if (objectB->collider_type == collider_enemy_static)
             {
                 movable_ground* ground_instance = object_manager.FindMovable_GroundID(objectA->id);//movable_groundで同じIDのを探してインスタンスをもらう
                 EnemyStatic* enemy_instance = object_manager.FindEnemyStaticByID(objectB->id);
-                ground_instance->DeleteContactedEnemyList(enemy_instance);
+                if (enemy_instance != nullptr && ground_instance != nullptr) {
+                    ground_instance->DeleteContactedEnemyList(enemy_instance);
+                }
             }
         }
 
@@ -676,12 +696,16 @@ public:
             if (objectA->collider_type == collider_enemy_dynamic)
             {
                 EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectA->id);
-                enemy_instance->OutPlayerSensor();
+                if (enemy_instance != nullptr) {
+                    enemy_instance->OutPlayerSensor();
+                }
             }
             else if (objectB->collider_type == collider_enemy_dynamic)
             {
                 EnemyDynamic* enemy_instance = object_manager.FindEnemyDynamicByID(objectB->id);
-                enemy_instance->OutPlayerSensor();
+                if (enemy_instance != nullptr) {
+                    enemy_instance->OutPlayerSensor();
+                }
             }
         }
 
@@ -695,7 +719,13 @@ public:
             auto object = objectA->Item_name == ITEM_SPIRIT ? fixtureB : fixtureA;
 
             ItemSpirit* spirit_instance = item_manager.FindItem_Spirit_ByID(spirit->id);//ItemSpeedUpで同じIDのを探してインスタンスをもらう
-          
+            if (spirit_instance == nullptr) {
+                return;
+            }
+            if (spirit_instance->GetState() == Spirit_Collecting)
+            {
+                return;
+            }
             spirit_instance->DeleteCollidedObject(object->GetBody());
         }
 

--- a/player.cpp
+++ b/player.cpp
@@ -39,7 +39,7 @@ bool    Player::m_is_jumping = false;
 bool    Player::m_jump_pressed = false;
 bool     Player::m_direction = 1;
 
-
+bool    CollectSpirit_pressed = false;
 
 b2Body* player_body;
 
@@ -354,11 +354,12 @@ void Player::Update()
 
 //ソウルアイテム回収処理
 //----------------------------------------------------------------------------------------------------------------------------------------------------
-    if (Keyboard_IsKeyDown(KK_B) || state.buttonB)
+    if (!CollectSpirit_pressed && (Keyboard_IsKeyDownTrigger(KK_B) || state.buttonB))
     {
         ItemManager& itemManager = ItemManager::GetInstance();
         itemManager.SetCollectSpirit(true);
     }
+    CollectSpirit_pressed = (Keyboard_IsKeyDownTrigger(KK_B) || state.buttonB);
 
 
  //アンカーの処理


### PR DESCRIPTION
Bボタン長押しで起きるソウル回収のバグを解消した。

あと、なんかリザルトからもう一回ゲーム画面行ったらコインとエネミーがアクセス違反のエラーがたまーに起きたので、contactlistの中でmanagerから取得したものがnullptrじゃない時だけそのものの衝突処理をするようにした