### PR TITLE
修正：アンカー発射中及び通常攻撃中にプレイヤーの描画の向きが反転しないようにした

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -280,7 +280,13 @@ void Player::Update()
             {
                 m_body->ApplyLinearImpulse({ (GetSpeed() + adjust_speed)/3 , 0.0f }, player_point, true);
             }
-            m_direction = 1;
+
+
+            //使用中は左右反転できないようにした
+            if (Anchor::GetAnchorState() == Nonexistent_state)
+            {
+                m_direction = 1;
+            }
 
             if (draw_state == player_nomal_state)
             {
@@ -298,8 +304,12 @@ void Player::Update()
             {
                 m_body->ApplyLinearImpulse({ ((GetSpeed()) + adjust_speed)/-3 , 0.0f }, player_point, true);
             }
-            m_direction = 0;
 
+            //使用中は左右反転できないようにした
+            if (Anchor::GetAnchorState() == Nonexistent_state)
+            {
+                m_direction = 0;
+            }
 
             if (draw_state == player_nomal_state)
             {
@@ -649,6 +659,7 @@ void Player::Draw()
       
        
    
+       
 
 
         switch (draw_state)


### PR DESCRIPTION
アンカー発射中及び通常攻撃中にプレイヤーの描画の向きが反転しないようにした