### PR TITLE
修正：カメラの表示範囲を変更できるようにした

### DIFF
--- a/display.cpp
+++ b/display.cpp
@@ -10,10 +10,11 @@
 #include"display.h"
 #include"keyboard.h"
 #include"anchor_spirit.h"
+#include"tool.h"
 
 // 静的メンバ変数の定義（1回だけ行う）
-
-float display::m_display_scale = 1;//スケールの初期値の倍率
+//表示範囲を渡して　その範囲を表示するための拡大率を受け取っている
+float display::m_display_scale = calculateScale(DISPLAY_RANGE_TO_SCALE);//スケールの初期値の倍率
 
 
 
@@ -58,14 +59,16 @@ void display::Update()
 
 	if (AnchorSpirit::GetAnchorLevel() == 3)
 	{
-		if (GetDisplayScale() >= 0.5)
+		//自動で倍率を調整するよ
+		if (GetDisplayScale() >= 0.5 *calculateScale(DISPLAY_RANGE_TO_SCALE))
 		{
 			SetDisplayScale(-0.01);
 		}
 	}
 	else
 	{
-		if (GetDisplayScale() <= 1)
+		//自動で倍率を調整するよ
+		if (GetDisplayScale() <= 1* calculateScale(DISPLAY_RANGE_TO_SCALE))
 		{
 			SetDisplayScale(0.01);
 		}

--- a/display.h
+++ b/display.h
@@ -15,6 +15,8 @@
 #define DEFAULT_DISPLAY_WIDTH (650)
 #define DEFAULT_DISPLAY_HEIGHT (540)
 
+#define DISPLAY_RANGE_TO_SCALE (0.7)
+
 class display
 {
 public:

--- a/player.cpp
+++ b/player.cpp
@@ -17,6 +17,7 @@
 #include"sound.h"
 #include"hit_stop.h"
 #include"camera_shake.h"
+#include"display.h"
 
 
 
@@ -113,7 +114,7 @@ void Player::Initialize(b2Vec2 position, b2Vec2 body_size, b2Vec2 sensor_size)
 
 
     SetSize(body_size);//プレイヤー表示をするためにセットする
-    SetSensorSize(sensor_size);//センサー表示をするためにセット
+    SetSensorSize(b2Vec2(sensor_size.x* DISPLAY_RANGE_TO_SCALE,sensor_size.y * DISPLAY_RANGE_TO_SCALE));//センサー表示をするためにセット
 
 
 
@@ -125,8 +126,8 @@ void Player::Initialize(b2Vec2 position, b2Vec2 body_size, b2Vec2 sensor_size)
 
     //センサーの設定用の
     b2Vec2 size_sensor;//命名すまん
-    size_sensor.x = sensor_size.x / BOX2D_SCALE_MANAGEMENT;
-    size_sensor.y = sensor_size.y / BOX2D_SCALE_MANAGEMENT;
+    size_sensor.x = sensor_size.x / BOX2D_SCALE_MANAGEMENT*DISPLAY_RANGE_TO_SCALE;
+    size_sensor.y = sensor_size.y / BOX2D_SCALE_MANAGEMENT*DISPLAY_RANGE_TO_SCALE;
 
 
 
@@ -854,17 +855,17 @@ void Player::Draw()
         //センサー描画
 
 
-        //// シェーダリソースを設定
-        //GetDeviceContext()->PSSetShaderResources(0, 1, &g_player_sensor_Texture);
+        // シェーダリソースを設定
+        GetDeviceContext()->PSSetShaderResources(0, 1, &g_player_sensor_Texture);
 
-        //DrawSprite(
-        //    { screen_center.x,
-        //      screen_center.y },
-        //    m_body->GetAngle(),
-        //    { GetSensorSize().x * scale,GetSensorSize().y * scale }
-        //);
-        //float size_sensor = GetSensorSize().x * scale;
-        //float size = GetSize().x * scale;
+        DrawSprite(
+            { screen_center.x,
+              screen_center.y },
+            m_body->GetAngle(),
+            { GetSensorSize().x * scale,GetSensorSize().y * scale }
+        );
+        float size_sensor = GetSensorSize().x * scale;
+        float size = GetSize().x * scale;
 
     }
 }

--- a/player.cpp
+++ b/player.cpp
@@ -18,6 +18,7 @@
 #include"hit_stop.h"
 #include"camera_shake.h"
 #include"display.h"
+#include<cmath>
 
 
 
@@ -231,6 +232,19 @@ void Player::Update()
     //モーションのDrawカウントを加算
     draw_cnt++;
     
+
+    //Sensorの変更フラグの管理
+    if (old_anchor_Lev != AnchorSpirit::GetAnchorLevel())
+    {
+        if ((old_anchor_Lev == 1 || old_anchor_Lev == 2)&& (AnchorSpirit::GetAnchorLevel()==1|| AnchorSpirit::GetAnchorLevel() == 2))
+        {
+        }
+        else
+        {
+            sensor_flag = false;
+        }  
+    }
+    old_anchor_Lev = AnchorSpirit::GetAnchorLevel();
     //センサーの画面サイズに応じた大きさの変動
     Player_sensor_size_change(AnchorSpirit::GetAnchorLevel());
 
@@ -612,19 +626,21 @@ void Player::Player_sensor_size_change(int anchor_level)
 {
     if (anchor_level < 3)//アンカーレベルの１、２の時
     {
-        if (GetSensorSize() == GetSensorSizeLev3())//センサーの大きさを取得して
+        if(sensor_flag==false)
         {
             b2Vec2 pos=GetPlayerBody()->GetPosition();
             Initialize(pos, b2Vec2(1, 2), GetSensorSizeLev1_2());
+            sensor_flag = true;
         }
     }
 
     if (anchor_level == 3)//アンカーレベルが３の時
     {
-        if (GetSensorSize() == GetSensorSizeLev1_2())//大きさを取得して差分があれば
+        if(sensor_flag==false)
         {
             b2Vec2 pos = GetPlayerBody()->GetPosition();
             Initialize(pos, b2Vec2(1, 2), GetSensorSizeLev3());
+            sensor_flag = true;
         }
     }
 }

--- a/player.h
+++ b/player.h
@@ -15,7 +15,8 @@
 
 
 #include"include/box2d/box2d.h"
-
+#include"tool.h"
+#include"display.h"
 #include"world_box2d.h"
 
 
@@ -178,9 +179,9 @@ private:
 	int draw_cnt;
 
 
-	//レベルに応じたセンサーの大きさを記述したもの
-	b2Vec2 Sensor_size_Lev1_2 = b2Vec2(40, 34);
-	b2Vec2 Sensor_size_Lev3 = b2Vec2(80, 68);
+	//レベルに応じたセンサーの大きさを記述したもの	displayの変更に伴って　センサーのサイズも自動で変わるようにした
+	b2Vec2 Sensor_size_Lev1_2 = b2Vec2(40*calculateScale(DISPLAY_RANGE_TO_SCALE), 34 * calculateScale(DISPLAY_RANGE_TO_SCALE));
+	b2Vec2 Sensor_size_Lev3 = b2Vec2(80*calculateScale(DISPLAY_RANGE_TO_SCALE), 68* calculateScale(DISPLAY_RANGE_TO_SCALE));
 };
 
 #endif // !PLAYER_H

--- a/player.h
+++ b/player.h
@@ -174,14 +174,22 @@ private:
 	//アンカーを使用中よフラグ
 	bool m_is_use_anchor = false;
 
+	//描画に利用してる　プレイヤーの状態を表したもの
 	player_draw_state draw_state;
 
+	//描画用のカウント
 	int draw_cnt;
+
+	
 
 
 	//レベルに応じたセンサーの大きさを記述したもの	displayの変更に伴って　センサーのサイズも自動で変わるようにした
 	b2Vec2 Sensor_size_Lev1_2 = b2Vec2(40*calculateScale(DISPLAY_RANGE_TO_SCALE), 34 * calculateScale(DISPLAY_RANGE_TO_SCALE));
 	b2Vec2 Sensor_size_Lev3 = b2Vec2(80*calculateScale(DISPLAY_RANGE_TO_SCALE), 68* calculateScale(DISPLAY_RANGE_TO_SCALE));
+
+	//センサーの管理に使う
+	bool sensor_flag;
+	int old_anchor_Lev;
 };
 
 #endif // !PLAYER_H

--- a/tool.cpp
+++ b/tool.cpp
@@ -108,3 +108,26 @@ int GetRandomInt(int min, int max) {
 double DegreesToRadians(double degrees) {
     return degrees * M_PI / 180.0;
 }
+
+
+// 表示範囲から倍率を計算する関数
+float calculateScale(float displayPercentage) {
+    if (displayPercentage <= 0 || displayPercentage > 100) {
+        throw std::invalid_argument("表示範囲は0より大きく100以下の値を指定してください。");
+    }
+
+    // 表示範囲（％）を倍率に変換
+    float scale = sqrt(1.0 / displayPercentage);
+    return scale;
+}
+
+// 倍率から表示範囲を計算する関数
+float calculateDisplayPercentage(float scale) {
+    if (scale <= 0) {
+        throw std::invalid_argument("倍率は0より大きい値を指定してください。");
+    }
+
+    // 表示範囲（％）を計算
+    float displayPercentage = 100.0 / pow(scale, 2);
+    return displayPercentage;
+}

--- a/tool.h
+++ b/tool.h
@@ -53,4 +53,11 @@ int GetRandomInt(int min, int max);
  */
 double DegreesToRadians(double degrees);
 
+// •\¦”ÍˆÍ‚©‚ç”{—¦‚ğŒvZ‚·‚éŠÖ”
+float calculateScale(float displayPercentage);
+
+
+// ”{—¦‚©‚ç•\¦”ÍˆÍ‚ğŒvZ‚·‚éŠÖ”
+float calculateDisplayPercentage(float scale);
+
 #endif // TOOL_H


### PR DESCRIPTION
カメラの表示範囲を変更できるようにした
カメラの表示範囲の変更に伴って変わるプレイヤーのセンサーのサイズなども
#dedineをいじることで一括で変更できるようにした