### PR TITLE
エネミーに直接触れた場合エネミーが消える処理の削除

### DIFF
--- a/enemy.cpp
+++ b/enemy.cpp
@@ -25,7 +25,6 @@ void Enemy::CollisionPlayer()
 {
 	//HPを減少させる
 	PlayerStamina::EditPlayerStaminaValue(-GetDamage());
-	SetUse(false);
 }
 
 //エネミーが動いている状態のオブジェクトに触れた時の処理


### PR DESCRIPTION
エネミーがプレイヤーに触れた際、ダメージを与える処理のみを残しエネミーを消す処理を削除しました