### PR TITLE
追加：マップの切り替え機能

### DIFF
--- a/field.cpp
+++ b/field.cpp
@@ -346,14 +346,14 @@ void Field::DeleteFieldObject(b2Body* delete_object)
 }
 
 //マップ切り替え
-void Field::LoadMap(MapType mapType)
+void Field::LoadMap(StageType stage_type)
 {
     // 現在のマップをクリア
     Field::Finalize();
 
     // マップタイプに応じて対応する CSV ファイルを読み込む
-    switch (mapType) {
-        case MapType::Stage1:
+    switch (stage_type) {
+        case StageType::Stage1:
             LoadCSV("asset/mapchip_stage_1_1.csv");
             break;
         // 他のステージを追加

--- a/field.cpp
+++ b/field.cpp
@@ -25,9 +25,6 @@
 #include"object_manager.h"
 #include"Item_Manager.h"
 
-
-
-
 // 2次元配列の静的メンバの初期化
 Field*** Field::m_p_field_array = nullptr;
 
@@ -346,4 +343,25 @@ void Field::DeleteFieldObject(b2Body* delete_object)
 			}
 		}
 	}
+}
+
+//マップ切り替え
+void Field::LoadMap(MapType mapType)
+{
+    // 現在のマップをクリア
+    Field::Finalize();
+
+    // マップタイプに応じて対応する CSV ファイルを読み込む
+    switch (mapType) {
+        case MapType::Stage1:
+            LoadCSV("asset/mapchip_stage_1_1.csv");
+            break;
+        // 他のステージを追加
+        default:
+            std::cerr << "Unknown map type" << std::endl;
+            return;
+    }
+
+    // 新しいマップを初期化
+    Initialize();
 }

--- a/field.h
+++ b/field.h
@@ -35,6 +35,13 @@ enum FieldTexture
 	enemy_static_texture,
 };
 
+enum class MapType {
+    Stage1,
+    Stage2,
+    Stage3,
+    // 他のステージを追加
+};
+
 class Field 
 {
 public:
@@ -48,6 +55,9 @@ public:
 
 	//csvファイルを読み込み、二次元配列として格納
 	static bool LoadCSV(const std::string& filename);
+
+	// マップの切り替え
+    void LoadMap(MapType mapType);
 
 	// サイズの取得と設定
 	b2Vec2 GetSize() const { return m_size; }
@@ -88,4 +98,3 @@ private:
 
 
 #endif // !FIELD_H
-

--- a/field.h
+++ b/field.h
@@ -35,7 +35,7 @@ enum FieldTexture
 	enemy_static_texture,
 };
 
-enum class MapType {
+enum class StageType {
     Stage1,
     Stage2,
     Stage3,
@@ -57,7 +57,7 @@ public:
 	static bool LoadCSV(const std::string& filename);
 
 	// マップの切り替え
-    void LoadMap(MapType mapType);
+    void LoadMap(StageType stage_type);
 
 	// サイズの取得と設定
 	b2Vec2 GetSize() const { return m_size; }


### PR DESCRIPTION
概要
マップ用のcsvファイルを切り替える機能を追加
一旦は機能の追加だけした

追加
マップ管理用のenum型
マップ切り替えのための関数LoadMap
