### PR TITLE
修正：アンカーの挙動

### DIFF
--- a/1-1_boss.cpp
+++ b/1-1_boss.cpp
@@ -281,10 +281,16 @@ void Boss_1_1::Update()
 		// デバック用　本番環境ではけす
 		
 		//アンカーポイントのボディを削除するデバック用
-		if (Keyboard_IsKeyDown(KK_Y))
+		if (Keyboard_IsKeyDown(KK_Y)&&debug_flag==0)
 		{
-			DestroyBossCore();
+			debug_flag = 60;
+			boss_field_level++;
 		}
+		if (debug_flag != 0)
+		{
+			debug_flag--;
+		}
+
 		//-------------------------------------------------------------------------------------------
 
 
@@ -359,7 +365,7 @@ void Boss_1_1::Update()
 			
 			if (static_cast<int>(sheet_cnt) == Shock_Wave_Start_Frame)
 			{
-				CreateShockWave(b2Vec2(1.5f, 4.0f), left_flag);
+				CreateShockWave(b2Vec2(5.0f, 6.0f), left_flag);
 				Shock_Wave_Fly_flag = true;
 
 				//エフェクトスタート
@@ -741,7 +747,7 @@ void Boss_1_1::CreateChargeAttack(b2Vec2 attack_size, bool left)
 
 
 		//地面を破壊
-		boss_field_level++;
+	/*	boss_field_level++;*/
 
 		
 
@@ -770,10 +776,12 @@ void Boss_1_1::CreateShockWave(b2Vec2 attack_size, bool left)
 
 		if (left) {
 			body.position.Set(boss_pos.x - (boss_size.x / 3) - (size.x / 2), boss_pos.y + boss_size.y / 2-size.y/2);
+			ShockWaveLeftFlag = true;
 		}
 		else
 		{
 			body.position.Set(boss_pos.x + (boss_size.x / 3) + (size.x / 2), boss_pos.y + boss_size.y / 2-size.y / 2);
+			ShockWaveLeftFlag = false;
 		}
 		body.angle = 0.0f;
 		body.fixedRotation = true;//回転を固定にする
@@ -818,7 +826,7 @@ void Boss_1_1::ShockWaveUpdate(void)
 		if (GetAttackBody() != nullptr)
 		{
 			float minus_flag = 1;
-			if (left_flag == true)
+			if (ShockWaveLeftFlag == true)
 			{
 				minus_flag = -1;
 			}
@@ -1318,7 +1326,9 @@ void Boss_1_1::EffectDraw()
 				GetDeviceContext()->PSSetShaderResources(0, 1, &g_boss_charge_attack_effect);
 
 				// コライダーの位置の取得（プレイヤーの位置）
-				b2Vec2 attack_pos = GetAttackBody()->GetPosition();
+				b2Vec2 attack_pos;
+				attack_pos.x = GetAttackBody()->GetPosition().x;
+				attack_pos.y= GetAttackBody()->GetPosition().y+ (GetAttackDrawSize().y/BOX2D_SCALE_MANAGEMENT/2);
 
 				// プレイヤー位置を考慮してスクロール補正を加える
 				//取得したbodyのポジションに対してBox2dスケールの補正を加える
@@ -1329,7 +1339,7 @@ void Boss_1_1::EffectDraw()
 				
 				
 
-				DrawDividedSpriteBoss(XMFLOAT2(attack_draw_x, attack_draw_y), 0.0f, XMFLOAT2(GetAttackDrawSize().x * scale*3 , GetAttackDrawSize().y * scale*3), 5, 6, charge_attack_effect_sheet_cnt, effect_alpha, left_flag);
+				DrawDividedSpriteBoss(XMFLOAT2(attack_draw_x, attack_draw_y), 0.0f, XMFLOAT2(GetAttackDrawSize().x * scale*7 , GetAttackDrawSize().y * scale*7), 5, 6, charge_attack_effect_sheet_cnt, effect_alpha, left_flag);
 			}
 		
 		}
@@ -1351,7 +1361,7 @@ void Boss_1_1::EffectDraw()
 
 				//これ貰ったスプライトが向きが反対だったから修正
 				bool left = 1;
-				if (left_flag)
+				if (ShockWaveLeftFlag)
 				{
 					left = 0;
 				}

--- a/1-1_boss.cpp
+++ b/1-1_boss.cpp
@@ -533,7 +533,7 @@ void Boss_1_1::BossCoreUpdate()
 		sheet_cnt = 0;//シートカウントをリセット
 		now_boss_state = charge_attack_state;
 		CoreDeleteFlag = false;
-		Anchor::SetAnchorState(Deleting_state);
+		
 	}
 }
 
@@ -627,9 +627,6 @@ void Boss_1_1::DestroyBossCore(void)
 		b2World* world = box2d_world.GetBox2dWorldPointer();//ワールドのポインタを持ってくる
 
 
-	
-
-	
 
 		world->DestroyBody(GetAnchorPointBody());
 
@@ -747,7 +744,7 @@ void Boss_1_1::CreateChargeAttack(b2Vec2 attack_size, bool left)
 
 
 		//地面を破壊
-	/*	boss_field_level++;*/
+		boss_field_level++;
 
 		
 

--- a/1-1_boss.h
+++ b/1-1_boss.h
@@ -277,7 +277,7 @@ private:
 	bool destroy_mini_golem_flag=false;
 
 	
-
+	int debug_flag = 0;
 
 
 	float sheet_cnt;//シートの管理で使っている
@@ -341,7 +341,9 @@ private:
 
 	bool Shock_Wave_Fly_flag=false;
 	static constexpr int Shock_Wave_time_Frame = 180;
-	int Now_Shock_Wave_time_Frame = 0;
+	int Now_Shock_Wave_time_Frame = 0;//ショックウェーブの現在の管理
+	bool ShockWaveLeftFlag = true;
+
 
 
 	//-------------------------------------------------------------------------------------------

--- a/anchor.cpp
+++ b/anchor.cpp
@@ -327,21 +327,23 @@ void Anchor::ThrowAnchorToAP()
 	b2Body* body=AnchorPoint::GetTargetAnchorPointBody();
 
 	
+	if (AnchorPoint::GetTargetAnchorPointBody() != nullptr)
+	{
+		b2Vec2 to_pos = AnchorPoint::GetTargetAnchorPointBody()->GetPosition();
 
-	b2Vec2 to_pos = AnchorPoint::GetTargetAnchorPointBody()->GetPosition();
+		// 値が異常かチェック
+		if (std::abs(to_pos.x) > 1e6 || std::abs(to_pos.y) > 1e6) {
+			// 異常値の場合、エラーログを出力するか処理をスキップ
+			std::cerr << "Error: to_pos has invalid values. x=" << to_pos.x << ", y=" << to_pos.y << std::endl;
+			SetAnchorState(Pulling_state);
+			return; // 処理を中断
+		}
+		b2Vec2 velocity = to_pos - anchor_pos;
+		velocity.Normalize(); // 単位ベクトル化して方向を決定
+		velocity *= 20; // 投擲速度を設定	
 
-	// 値が異常かチェック
-	if (std::abs(to_pos.x) > 1e6 || std::abs(to_pos.y) > 1e6) {
-		// 異常値の場合、エラーログを出力するか処理をスキップ
-		std::cerr << "Error: to_pos has invalid values. x=" << to_pos.x << ", y=" << to_pos.y << std::endl;
-		SetAnchorState(Pulling_state);
-		return; // 処理を中断
+		g_anchor_instance->GetAnchorBody()->SetLinearVelocity(velocity);//ここで力を加えてる
 	}
-	b2Vec2 velocity = to_pos - anchor_pos;
-	velocity.Normalize(); // 単位ベクトル化して方向を決定
-	velocity *= 20; // 投擲速度を設定	
-
-	g_anchor_instance->GetAnchorBody()->SetLinearVelocity(velocity);//ここで力を加えてる
 
 }
 	
@@ -406,6 +408,26 @@ void Anchor::DeleteRotateJoint(void)
 	}
 }
 
+
+bool Anchor::CheckAnchorJoint()
+{
+	b2Body* body = g_anchor_instance->GetAnchorBody();
+	if (body)
+	{
+		// ボディが持つジョイントのリストを取得
+		b2JointEdge* jointEdge = body->GetJointList();
+		if (jointEdge)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+		
+	
+}
 
 
 void Anchor::PullingAnchor(void)

--- a/anchor.cpp
+++ b/anchor.cpp
@@ -475,8 +475,6 @@ void Anchor::DrawChain()
 
 	
 
-	
-
 	// ‹——£‚ðŒvŽZ
 	float distance = b2Distance(anchor_position, player_position);
 

--- a/anchor.cpp
+++ b/anchor.cpp
@@ -409,25 +409,7 @@ void Anchor::DeleteRotateJoint(void)
 }
 
 
-bool Anchor::CheckAnchorJoint()
-{
-	b2Body* body = g_anchor_instance->GetAnchorBody();
-	if (body)
-	{
-		// ボディが持つジョイントのリストを取得
-		b2JointEdge* jointEdge = body->GetJointList();
-		if (jointEdge)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-	}
-		
-	
-}
+
 
 
 void Anchor::PullingAnchor(void)

--- a/anchor.h
+++ b/anchor.h
@@ -111,6 +111,10 @@ public:
 	static void DeleteNormalAttackAnchor();
 
 	void DeleteNormalAttackAnchorBody();
+	 
+	static bool CheckAnchorJoint(void);
+
+	static bool CheckAnchorNearPlayer(void);
 
 
 

--- a/anchor.h
+++ b/anchor.h
@@ -112,9 +112,9 @@ public:
 
 	void DeleteNormalAttackAnchorBody();
 	 
-	static bool CheckAnchorJoint(void);
 
-	static bool CheckAnchorNearPlayer(void);
+
+
 
 
 

--- a/contactlist.h
+++ b/contactlist.h
@@ -179,6 +179,11 @@ public:
                 Anchor::SetAnchorState(Deleting_state);
             }
 
+            if (Anchor::GetAnchorState() == Throwing_state)
+            {
+                Anchor::SetAnchorState(Deleting_state);
+            }
+
 
         }
 
@@ -256,88 +261,91 @@ public:
             contactPoint = worldManifold.points[0];
 
 
-
-            //木のオブジェクトの引っ張る処理
-            if (objectA->object_name == Object_Wood || objectB->object_name == Object_Wood)
+            //状態が投げてる時にのみ以降する
+            if (Anchor::GetAnchorState() == Connected_state)
             {
-                //どちらが木のオブジェクトか特定
-                if (objectA->object_name == Object_Wood)//Aが木のオブジェクト
+                //木のオブジェクトの引っ張る処理
+                if (objectA->object_name == Object_Wood || objectB->object_name == Object_Wood)
                 {
-                    wood* wood_instance = object_manager.FindWoodByID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
-                    wood_instance->Pulling_wood(objectA->add_force);//木を引っ張る処理を呼び出す
-                }
-                else
-                {
-                    wood* wood_instance = object_manager.FindWoodByID(objectB->id);
-                    wood_instance->Pulling_wood(objectB->add_force);
+                    //どちらが木のオブジェクトか特定
+                    if (objectA->object_name == Object_Wood)//Aが木のオブジェクト
+                    {
+                        wood* wood_instance = object_manager.FindWoodByID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
+                        wood_instance->Pulling_wood(objectA->add_force);//木を引っ張る処理を呼び出す
+                    }
+                    else
+                    {
+                        wood* wood_instance = object_manager.FindWoodByID(objectB->id);
+                        wood_instance->Pulling_wood(objectB->add_force);
+                    }
+
                 }
 
-            }
-
-            //岩のオブジェクトの引っ張る処理
-            if (objectA->object_name == Object_Rock || objectB->object_name == Object_Rock)
-            {
-                //どちらが岩のオブジェクトか特定
-                if (objectA->object_name == Object_Rock)//Aが岩のオブジェクト
+                //岩のオブジェクトの引っ張る処理
+                if (objectA->object_name == Object_Rock || objectB->object_name == Object_Rock)
                 {
-                    rock* rock_instance = object_manager.FindRockByID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
-                    rock_instance->Pulling_rock(objectA->add_force);//木を引っ張る処理を呼び出す
-                }
-                else
-                {
-                    rock* rock_instance = object_manager.FindRockByID(objectB->id);//woodで同じIDのを探してインスタンスをもらう
-                    rock_instance->Pulling_rock(objectB->add_force);//木を引っ張る処理を呼び出す
-                }
+                    //どちらが岩のオブジェクトか特定
+                    if (objectA->object_name == Object_Rock)//Aが岩のオブジェクト
+                    {
+                        rock* rock_instance = object_manager.FindRockByID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
+                        rock_instance->Pulling_rock(objectA->add_force);//木を引っ張る処理を呼び出す
+                    }
+                    else
+                    {
+                        rock* rock_instance = object_manager.FindRockByID(objectB->id);//woodで同じIDのを探してインスタンスをもらう
+                        rock_instance->Pulling_rock(objectB->add_force);//木を引っ張る処理を呼び出す
+                    }
 
-            }
+                }
 
 
-            //静的動的のオブジェクトの
-            if (objectA->object_name == Object_Static_to_Dynamic || objectB->object_name == Object_Static_to_Dynamic)
-            {
-                //どちらが岩のオブジェクトか特定
-                if (objectA->object_name == Object_Static_to_Dynamic)//Aが静的動的のオブジェクト
+                //静的動的のオブジェクトの
+                if (objectA->object_name == Object_Static_to_Dynamic || objectB->object_name == Object_Static_to_Dynamic)
                 {
-                    static_to_dynamic_block* static_to_dynamic_block_instance = object_manager.FindStatic_to_Dynamic_BlcokID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
-                    static_to_dynamic_block_instance->Change_dynamic();//静的を動的にする
+                    //どちらが岩のオブジェクトか特定
+                    if (objectA->object_name == Object_Static_to_Dynamic)//Aが静的動的のオブジェクト
+                    {
+                        static_to_dynamic_block* static_to_dynamic_block_instance = object_manager.FindStatic_to_Dynamic_BlcokID(objectA->id);//woodで同じIDのを探してインスタンスをもらう
+                        static_to_dynamic_block_instance->Change_dynamic();//静的を動的にする
+                    }
+                    else
+                    {
+                        static_to_dynamic_block* static_to_dynamic_block_instance = object_manager.FindStatic_to_Dynamic_BlcokID(objectB->id);//woodで同じIDのを探してインスタンスをもらう
+                        static_to_dynamic_block_instance->Change_dynamic();//静的を動的にする
+                    }
                 }
-                else
-                {
-                    static_to_dynamic_block* static_to_dynamic_block_instance = object_manager.FindStatic_to_Dynamic_BlcokID(objectB->id);//woodで同じIDのを探してインスタンスをもらう
-                    static_to_dynamic_block_instance->Change_dynamic();//静的を動的にする
-                }
-            }
 
-            //ボスのコア
-            if (objectA->object_name == Boss_core || objectB->object_name == Boss_core)
-            {
-                //どちらが岩のオブジェクトか特定
-                if (objectA->object_name == Boss_core)//Aが静的動的のオブジェクト
+                //ボスのコア
+                if (objectA->object_name == Boss_core || objectB->object_name == Boss_core)
                 {
-                    boss.BossDamaged();
-                    boss.SetCoreDeleteFlag(true);
-              
-                }
-                else
-                {
-                    boss.BossDamaged();
-                    boss.SetCoreDeleteFlag(true);
-                  
-                }
-            }
+                    //どちらが岩のオブジェクトか特定
+                    if (objectA->object_name == Boss_core)//Aが静的動的のオブジェクト
+                    {
+                        boss.BossDamaged();
+                        boss.SetCoreDeleteFlag(true);
 
-            if (objectA->object_name == Boss_pillar || objectB->object_name == Boss_pillar)
-            {
-                //どちらがボスの部屋の柱
-                if (objectA->object_name == Boss_pillar)//Aが木のオブジェクト
-                {
-                    boss_pillar* pillar_instance = object_manager.FindBossPillar(objectA->id);//woodで同じIDのを探してインスタンスをもらう
-                    pillar_instance->Pulling_pillar(objectA->add_force);//木を引っ張る処理を呼び出す
+                    }
+                    else
+                    {
+                        boss.BossDamaged();
+                        boss.SetCoreDeleteFlag(true);
+
+                    }
                 }
-                else
+
+                if (objectA->object_name == Boss_pillar || objectB->object_name == Boss_pillar)
                 {
-                    boss_pillar* pillar_instance = object_manager.FindBossPillar(objectB->id);
-                    pillar_instance->Pulling_pillar(objectB->add_force);
+                    //どちらがボスの部屋の柱
+                    if (objectA->object_name == Boss_pillar)//Aが木のオブジェクト
+                    {
+                        boss_pillar* pillar_instance = object_manager.FindBossPillar(objectA->id);//woodで同じIDのを探してインスタンスをもらう
+                        pillar_instance->Pulling_pillar(objectA->add_force);//木を引っ張る処理を呼び出す
+                    }
+                    else
+                    {
+                        boss_pillar* pillar_instance = object_manager.FindBossPillar(objectB->id);
+                        pillar_instance->Pulling_pillar(objectB->add_force);
+                    }
                 }
             }
        

--- a/player.cpp
+++ b/player.cpp
@@ -516,6 +516,9 @@ void Player::Update()
         Anchor::PullingAnchor();
 
 
+      
+
+
         if (g_anchor_frame_management_number > 120)
         {
             g_anchor_frame_management_number = 0;

--- a/player.cpp
+++ b/player.cpp
@@ -487,12 +487,12 @@ void Player::Update()
 
         if (180 < g_anchor_frame_management_number)
         {
+            g_anchor_frame_management_number = 0;
             Anchor::SetAnchorState(Pulling_state);
         }
 
+     
        
-       
-
 
         //ここはコンタクトリストないの接触判定から接触状態へと移行
         break;
@@ -509,12 +509,19 @@ void Player::Update()
 
     case Pulling_state://引っ張っている状態
 
+        g_anchor_frame_management_number++;
         //呼ばれた回数でするかね　とりあえず2秒で
-        if (g_anchor_frame_management_number > 100)
+      
+        Anchor::DeleteRotateJoint();
+        Anchor::PullingAnchor();
+
+
+        if (g_anchor_frame_management_number > 120)
         {
-            Anchor::DeleteRotateJoint();
-            Anchor::PullingAnchor();
+            g_anchor_frame_management_number = 0;
+            Anchor::SetAnchorState(Deleting_state);
         }
+       
 
 
         if ((state.rightTrigger) || (Keyboard_IsKeyDown(KK_G)))

--- a/player.cpp
+++ b/player.cpp
@@ -491,6 +491,7 @@ void Player::Update()
             Anchor::SetAnchorState(Pulling_state);
         }
 
+      
      
        
 
@@ -512,11 +513,16 @@ void Player::Update()
         g_anchor_frame_management_number++;
         //呼ばれた回数でするかね　とりあえず2秒で
       
-        Anchor::DeleteRotateJoint();
-        Anchor::PullingAnchor();
+        if (g_anchor_frame_management_number > 60)
+        {
+            Anchor::PullingAnchor();
+            Anchor::DeleteRotateJoint();
+        }
 
 
-      
+       
+           
+        
 
 
         if (g_anchor_frame_management_number > 120)


### PR DESCRIPTION
アンカーの向かったさきがボディが削除されるとアンカーがプルプルするのを修正した
今のところエラーはないがバグが発生したらまた修正する
アンカー周りはゲームの根幹に関わるので優先的に対象したい　バグ見つけたら報告して

あとアンカーの戻りの時にボスのコアを触れたりしたのでそれを修正