### PR TITLE
追加：アンカーのヒット時のアンカーが光るようにエフェクトを追加した

### DIFF
--- a/anchor.h
+++ b/anchor.h
@@ -113,6 +113,7 @@ public:
 	void DeleteNormalAttackAnchorBody();
 	 
 
+	static void DrawAnchorHitEffect(void);
 
 
 
@@ -185,6 +186,10 @@ private:
 
 
 	static AnchorState now_anchor_state;
+
+	bool anchor_hit_effect_flag=false;
+
+	int anchor_hit_effect_sheet_cnt;
 };
 
 


### PR DESCRIPTION
追加：アンカーのヒット時にアンカーを光るようにした

見たらわかると思う今回は複雑なことしてない
ただアンカーの座標を参照しているけど、アンカーの描画の際にアンカーの大きさに関して情報を関数ないのみで完結させちゃってるため、
アンカーのヒットエフェクトを右上にずらしている処理がアンカーのレベルに応じて変更はされてない
まあ見た目はあんまり気にならなかったから一旦出す
指摘があったら変更できる