### PR TITLE
修正：コインのエフェクトを調整した、それに伴う描画の差分

### DIFF
--- a/Change_Enemy_Filter_and_Body.cpp
+++ b/Change_Enemy_Filter_and_Body.cpp
@@ -159,7 +159,7 @@ void change_enemy_filter_and_body::Update()
 
 }
 
-void change_enemy_filter_and_body::Draw()
+void change_enemy_filter_and_body::DrawFront()
 {
 
 

--- a/Change_Enemy_Filter_and_Body.h
+++ b/Change_Enemy_Filter_and_Body.h
@@ -22,7 +22,7 @@ public:
 
 	void Initialize();
 	void Update();
-	void Draw();
+	void DrawFront();
 	void Finalize();
 
 

--- a/Item_Coin.cpp
+++ b/Item_Coin.cpp
@@ -217,7 +217,7 @@ void ItemCoin::DrawEffect()
             { draw_x,
              draw_y },
             0.0,
-            { GetSize().x * scale * 1.5f,GetSize().y * scale * 1.5f },
+            { GetSize().x * scale * 2.5f,GetSize().y * scale * 2.5f },
             4, 3,
             coin_effect_sheet_cnt / 4,
             3.0

--- a/Item_Manager.cpp
+++ b/Item_Manager.cpp
@@ -110,14 +110,27 @@ void ItemManager::DrawAll() {
     for (auto& w : m_SpeedUp_List) {
         w->Draw();
     }
-    for (auto& w : m_Spirit_List) {
-        w->Draw();
-    }
+   
 	for (auto& w : m_Coin_List) {
 		w->Draw();
 	}
-	Item_Coin_UI::Draw();
+	
 }
+
+// 全てのアイテムを描画
+void ItemManager::DrawFront() {
+ 
+    //魂も前列に描画
+    for (auto& w : m_Spirit_List) {
+        w->Draw();
+    }
+
+    for (auto& w : m_Coin_List) {
+        w->DrawEffect();
+    }
+    Item_Coin_UI::Draw();
+}
+
 
 // 全てのアイテムを破棄
 void ItemManager::FinalizeAll() {

--- a/Item_Manager.h
+++ b/Item_Manager.h
@@ -63,6 +63,9 @@ public:
 	// 全てのアイテムを描画
 	void DrawAll();
 
+	//全面の描画処理　エフェクトなど
+	void DrawFront();
+
 	// 全てのアイテムを破棄
 	void FinalizeAll();
 

--- a/field.cpp
+++ b/field.cpp
@@ -348,8 +348,7 @@ void Field::Draw()
 		}
 	}
 
-	itemManager.DrawAll();
-	objectManager.DrawAll();
+
 	
 
 

--- a/game.cpp
+++ b/game.cpp
@@ -275,10 +275,15 @@ void Game::Draw(void)
     //ボスの描画処理
     boss.Draw();
 
+
+
+    //描画の順番を調整するためにDrawのみ、外に出す
+    itemManager.DrawAll();
+    objectManager.DrawAll();
     //フィールドの描画処理
     Field::Draw();
 
-   
+ 
 
     //プレイヤーの描画処理
     player.Draw();
@@ -286,6 +291,10 @@ void Game::Draw(void)
     //アンカーの描画処理
     Anchor::Draw();
 
+
+
+    itemManager.DrawFront();
+    objectManager.DrawFront();
 
 
     //衝突時のエフェクト

--- a/game.h
+++ b/game.h
@@ -16,6 +16,8 @@
 #include"directx_controller.h"
 #include"UI_StaminaSpirit_Gauge.h"
 #include"1-1_boss.h"
+#include"object_manager.h"
+#include"Item_Manager.h"
 
 
 class Game
@@ -47,6 +49,11 @@ private:
 	Player player;
 	StaminaSpiritGauge stamina_spirit_gauge;
 	Boss_1_1 &boss =Boss_1_1::GetInstance();
+
+
+
+	ObjectManager& objectManager = ObjectManager::GetInstance();
+	ItemManager& itemManager = ItemManager::GetInstance();
 };
 
 

--- a/object_manager.cpp
+++ b/object_manager.cpp
@@ -625,10 +625,17 @@ void ObjectManager::DrawAll() {
         w->Draw();
     }
 
-    for (auto& w : change_filter_boidy_enemy_list) {
-        w->Draw();
-    }
+  
     Item_Coin_UI::Draw();
+}
+
+
+//オブジェクトのエフェクトなどを最前列にしたい
+void ObjectManager::DrawFront()
+{
+    for (auto& w : change_filter_boidy_enemy_list) {
+        w->DrawFront();
+    }
 }
 
 // 全ての木を破棄

--- a/object_manager.h
+++ b/object_manager.h
@@ -159,6 +159,10 @@ public:
     // 全てのオブジェクトを描画
     void DrawAll();
 
+
+    //全面に表示する　UI　エフェクトなど
+    void DrawFront();
+
     // 全てのオブジェクトを破棄
     void FinalizeAll();
 


### PR DESCRIPTION
コインのエフェクトをプレイヤーよりも前列に表示したい関係で、
item.managerとobject.managerにフロントDrawを作成した　エフェクトなどはこちらで描画したい

これの変更に伴い
描画の管理を統一したかったためFieldDraｗの中にあった、オブジェクトとアイテムのDrawをGame.cppに移動した

また、これの変更で魂の描画処理もFrontに移行した
また敵が吹っ飛ぶ処理も前列に表示に変更した