### PR TITLE
修正：releaseでビルドできるように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.vs/DX21_PuzzleGame
 /DX21_PuzzleGame/x64/Debug
 /x64/Debug
+/DX21_PuzzleGame/x64/Release

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /DX21_PuzzleGame/x64/Debug
 /x64/Debug
 /DX21_PuzzleGame/x64/Release
+/x64/Release

--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -126,7 +126,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>box2d\Debug;%(AdditionalLibraryDirectories);cri\libs\x64</AdditionalLibraryDirectories>
       <AdditionalDependencies>box2d.lib;Xinput.lib;cri_ware_pcx64_le_import.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
+    <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
@@ -120,6 +120,7 @@
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>cri\criinclude;cri\common;cri\cridata;cri\libs;cri\common\include</AdditionalIncludeDirectories>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -110,26 +110,23 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>box2d\Debug;%(AdditionalLibraryDirectories);cri\libs\x64</AdditionalLibraryDirectories>
-      <AdditionalDependencies>box2d.lib;Xinput.lib;cri_ware_pcx64_le_import.lib;%(AdditionalDependencies);</AdditionalDependencies>
+      <AdditionalDependencies>box2d.lib;Xinput.lib;cri_ware_pcx64_le_import.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>cri\criinclude;cri\common;cri\cridata;cri\libs;cri\common\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>cri\libs</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);cri_ware_pcx64_le_import.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>box2d\Debug;%(AdditionalLibraryDirectories);cri\libs\x64</AdditionalLibraryDirectories>
+      <AdditionalDependencies>box2d.lib;Xinput.lib;cri_ware_pcx64_le_import.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/DX21_PuzzleGame.vcxproj.filters
+++ b/DX21_PuzzleGame.vcxproj.filters
@@ -264,9 +264,7 @@
     <ClCompile Include="dead_production.cpp">
       <Filter>ソースファイル</Filter>
     </ClCompile>
-    <ClCompile Include="UI_Blcok.cpp">
-      <Filter>リソースファイル</Filter>
-    </ClCompile>
+    <ClCompile Include="UI_Block.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="enemy.h">


### PR DESCRIPTION
#### PR Classification
デバッグ設定の修正とファイルの整理。

#### PR Summary
デバッグ設定の修正と不要な依存関係の削除、ファイル名の修正を行いました。
- `.gitignore`にデバッグおよびリリースビルドのパスを追加
- `DX21_PuzzleGame.vcxproj`でデバッグライブラリの使用を有効化し、不要なタグを削除
- `DX21_PuzzleGame.vcxproj.filters`でファイル名の誤りを修正 (`UI_Blcok.cpp`から`UI_Block.cpp`に変更)

コメント
かなり適当なことしたので、もしかしたらなにか問題が起きるかも