### PR TITLE
修正：通常攻撃の呼び出しを削除

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -647,11 +647,11 @@ void Player::Update()
     }
 
 
-    //通常攻撃のアンカーの呼び出し
-    if ((Keyboard_IsKeyDown(KK_N) || (state.buttonX)) && Anchor::GetAnchorState() == Nonexistent_state)//何も存在しない状態でボタン入力で移行する
-    {
-        Anchor::SetAnchorState(WaitCreateNormalAttackDraw_cnt_state);
-    }
+    ////通常攻撃のアンカーの呼び出し
+    //if ((Keyboard_IsKeyDown(KK_N) || (state.buttonX)) && Anchor::GetAnchorState() == Nonexistent_state)//何も存在しない状態でボタン入力で移行する
+    //{
+    //    Anchor::SetAnchorState(WaitCreateNormalAttackDraw_cnt_state);
+    //}
 
  
     //プレーの向いている方向　swtich文的の仕様的に外でやる


### PR DESCRIPTION
通常攻撃が強すぎて便利すぎて楽しさに繋がっていないので通常攻撃の呼び出しを削除