### PR TITLE
soundの追加

### DIFF
--- a/cri/cridata/Public/CueSheet_0.h
+++ b/cri/cridata/Public/CueSheet_0.h
@@ -5,15 +5,15 @@
  *  ACB  Ver.        : Ver.1.44.1
  *  File Path        : C:/Users/k3821/Documents/CRIWARE/CriAtomCraft/projects/HEW_sound2/Public/WorkUnit_0
  *  File Name        : CueSheet_0.h
- *  File Size        : 40525824 bytes
- *  Date Time        : 2025/02/18 17:35:46
+ *  File Size        : 40873440 bytes
+ *  Date Time        : 2025/02/21 11:43:22
  *  Target           : Public
- *  Cues             : 57
+ *  Cues             : 61
  *  CueSheet Comment : 
  *  Stream Awb Path  : C:/Users/k3821/Documents/CRIWARE/CriAtomCraft/projects/HEW_sound2/Public/WorkUnit_0/CueSheet_0.awb
  *===========================================================================*/
 
-#define CRI_CUESHEET_0_CUENUM (57)
+#define CRI_CUESHEET_0_CUENUM (61)
 
 /* AISAC Control List (AISAC Control ID) */
 
@@ -52,6 +52,10 @@
 #define CRI_CUESHEET_0_フレームアップ (49) /*  */
 #define CRI_CUESHEET_0_プレイヤーの着地音 (57) /*  */
 #define CRI_CUESHEET_0_プレイヤーのジャンプ音 (58) /*  */
+#define CRI_CUESHEET_0_残機減少         (63) /*  */
+#define CRI_CUESHEET_0_錨のスピードアップ (62) /*  */
+#define CRI_CUESHEET_0_攻撃無効         (64) /*  */
+#define CRI_CUESHEET_0_移動スピードアップ (65) /*  */
 #define CRI_CUESHEET_0_岩が落ちる音   (16) /*  */
 #define CRI_CUESHEET_0_宝を取る音      (17) /*  */
 #define CRI_CUESHEET_0_木が倒れる音   (18) /*  */

--- a/sound.h
+++ b/sound.h
@@ -111,7 +111,7 @@ enum Sound_Manager
 	Anchor_Thorw_Sound,//player.cpp crate_state
 	Anchor_Mark_Sound, //anchor_point.cpp
 
-	//プレイヤーSE 14個
+	//プレイヤーSE 17個
 	Player_Soul_Colect1_Sound,//playercpp update
 	Player_Damege_Sound, //player.cpp Player_Damaged
 	Player_Dead_Sound,//player_Stamina.cpp  EditPlayerStaminaValue
@@ -126,6 +126,10 @@ enum Sound_Manager
 	Player_Frame_Up_Sound,//player.cpp DrawAnchorLevel3Frame
 	Player_Jump_Start_Sound,//player.cpp update 変更済み
 	Player_Jump_End_Sound,//					変更済み
+	Player_Stock_Decrease_Sound,//		2/21追加　残機減少
+	Player_Buff_AnchorSpeedUp_Sound,//	2/21追加　錨のスピードアップ
+	Player_Buff_Invincible_Sound,//		2/21追加　攻撃無効
+	Player_Buff_SpeedUp_Sound,//		2/21追加　プレイヤーのスピードアップ
 
 	//環境SE 8個
 	Object_Rock_Fall_Sound,//static_to_dynamic_block.cpp  Update
@@ -233,6 +237,10 @@ static AppCueListItem g_cue_list[] = {
 	CRI_CUESHEET_0_フレームアップ,
 	CRI_CUESHEET_0_プレイヤーの着地音,
 	CRI_CUESHEET_0_プレイヤーのジャンプ音,
+	CRI_CUESHEET_0_残機減少,
+	CRI_CUESHEET_0_錨のスピードアップ,
+	CRI_CUESHEET_0_攻撃無効,
+	CRI_CUESHEET_0_移動スピードアップ,
 	CRI_CUESHEET_0_岩が落ちる音,
 	CRI_CUESHEET_0_宝を取る音,
 	CRI_CUESHEET_0_木が倒れる音,


### PR DESCRIPTION
残機減少
宝石によるバフ
・錨のスピードアップ
・攻撃無効
・プレイヤーのスピードアップ
※この順番に入れてあります

ステージ内のBGMのはじめを徐々に音量でかくなるようにした（はず）なので死亡時もこれを呼び出して、もともと入っている死亡音＋残機減少音を追加したらちょうどよくなるはず