### PR TITLE
修正：遺跡ステージの傾斜ブロックの修正

### DIFF
--- a/sloping_block.cpp
+++ b/sloping_block.cpp
@@ -315,12 +315,15 @@ void sloping_block::Finalize()
 		world->DestroyBody(SlopingBlock_body);
 	}
 
-	
-	//テクスチャの解放
-	UnInitTexture(g_sloping_block_left_down_Texture);
-	UnInitTexture(g_sloping_block_right_down_Texture);
+	if (g_sloping_block_left_down_Texture != NULL)
+	{
+		//テクスチャの解放
+		UnInitTexture(g_sloping_block_left_down_Texture);
+		UnInitTexture(g_sloping_block_right_down_Texture);
 
-
+		g_sloping_block_left_down_Texture = NULL;
+		g_sloping_block_right_down_Texture = NULL;
+	}
 }
 
 void sloping_block::SetPlayerCollided(bool flag)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6b1eecb6-e5f2-48ce-8e6a-a198ab25fb05)
これが斜面が普通のステージの斜面だったから修正した