### PR TITLE
追加：ボスムービーの追加

### DIFF
--- a/1-1_boss.cpp
+++ b/1-1_boss.cpp
@@ -116,7 +116,7 @@ Boss_1_1::Boss_1_1()
 }
 
 Boss_1_1::~Boss_1_1()
-{
+{ 
 }
 
 void Boss_1_1::Initialize(b2Vec2 position, b2Vec2 bodysize, bool left)

--- a/DX21_PuzzleGame.vcxproj
+++ b/DX21_PuzzleGame.vcxproj
@@ -143,6 +143,7 @@
     <ClCompile Include="anchor_point.cpp" />
     <ClCompile Include="anchor_spirit.cpp" />
     <ClCompile Include="bg.cpp" />
+    <ClCompile Include="boss_movie.cpp" />
     <ClCompile Include="boss_wall_object.cpp" />
     <ClCompile Include="bound_block.cpp" />
     <ClCompile Include="break_block.cpp" />
@@ -237,6 +238,7 @@
     <ClInclude Include="anchor_spirit.h" />
     <ClInclude Include="bg.h" />
     <ClInclude Include="blown_away_effect.h" />
+    <ClInclude Include="boss_movie.h" />
     <ClInclude Include="boss_wall_object.h" />
     <ClInclude Include="bound_block.h" />
     <ClInclude Include="break_block.h" />

--- a/DX21_PuzzleGame.vcxproj.filters
+++ b/DX21_PuzzleGame.vcxproj.filters
@@ -314,6 +314,9 @@
     <ClCompile Include="Item_Barrier.cpp" />
     <ClCompile Include="Item_Healing.cpp" />
     <ClCompile Include="Stamina_UI.cpp" />
+    <ClCompile Include="GamePause.cpp" />
+    <ClCompile Include="Item_DamageValue.cpp" />
+    <ClCompile Include="boss_movie.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="enemy.h">
@@ -659,6 +662,10 @@
     <ClInclude Include="result.h">
       <Filter>ヘッダーファイル\scene</Filter>
     </ClInclude>
+    <ClInclude Include="GamePause.h" />
+    <ClInclude Include="Item_DamageValue.h" />
+    <ClInclude Include="KeyInput_Flag.h" />
+    <ClInclude Include="boss_movie.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ソースファイル">

--- a/boss_movie.cpp
+++ b/boss_movie.cpp
@@ -14,7 +14,7 @@
 #include"Xinput.h"
 #include"Xinput_controller.h"
 
-static ID3D11ShaderResourceView* g_pause_Texture = NULL;//アンカーのテクスチャ
+static ID3D11ShaderResourceView* g_pause_Texture = NULL;//
 static ID3D11ShaderResourceView* g_skip_texture = NULL;//アンカーのテクスチャ
 static ID3D11ShaderResourceView* g_skip_button_texture = NULL;//アンカーのテクスチャ
 
@@ -48,7 +48,7 @@ void BossMovie::Update()
 	{
 		SceneManager& sceneManager = SceneManager::GetInstance();
 
-
+		sceneManager.SetStageName(STAGE_BOSS);
 		sceneManager.ChangeScene(SCENE_GAME);
 		return;
 

--- a/boss_movie.cpp
+++ b/boss_movie.cpp
@@ -1,0 +1,169 @@
+//-----------------------------------------------------------------------------------------------------
+// #name boss_movie.cpp
+// #description ボスの登場ムービーを再生するcppファイル
+// #make 2025/03/04　yuzu00117
+// #update 2025/03/04
+// #comment 追加・修正予定
+//          
+//----------------------------------------------------------------------------------------------------
+#include "boss_movie.h"
+#include "keyboard.h"
+#include "scene.h"
+#include "sprite.h"
+#include "texture.h"
+#include"Xinput.h"
+#include"Xinput_controller.h"
+
+static ID3D11ShaderResourceView* g_pause_Texture = NULL;//アンカーのテクスチャ
+static ID3D11ShaderResourceView* g_skip_texture = NULL;//アンカーのテクスチャ
+static ID3D11ShaderResourceView* g_skip_button_texture = NULL;//アンカーのテクスチャ
+
+static bool g_pressed = false;
+
+BossMovie::BossMovie()
+{
+}
+
+BossMovie::~BossMovie()
+{
+}
+
+void BossMovie::Initialize()
+{
+	video.Initialize("asset/movie/op.mp4", false);
+	g_pause_Texture = InitTexture(L"asset\\texture\\sample_texture\\video_pause.png");
+	g_skip_texture = InitTexture(L"asset\\texture\\sample_texture\\skip.png");
+	g_skip_button_texture = InitTexture(L"asset\\texture\\sample_texture\\skip_a.png");
+
+
+	m_pause = false;
+	
+}
+
+void BossMovie::Update()
+{
+	bool finished = video.Update();
+
+	if (finished)
+	{
+		SceneManager& sceneManager = SceneManager::GetInstance();
+
+
+		sceneManager.ChangeScene(SCENE_GAME);
+		return;
+
+	}
+#ifdef _DEBUG
+	if (!g_pressed && Keyboard_IsKeyDownTrigger(KK_X))
+	{
+		Video_State state = video.GetState();
+		if (state == Video_Start)
+		{
+			video.SetState(Video_Pause);
+			m_pause = !m_pause;
+		}
+		else if (state == Video_Pause)
+		{
+			video.SetState(Video_Resume);
+			m_pause = !m_pause;
+		}
+		else if (state == Video_Resume)
+		{
+			video.SetState(Video_Pause);
+			m_pause = !m_pause;
+		}
+	}
+	g_pressed = Keyboard_IsKeyDownTrigger(KK_X);
+
+	if (Keyboard_IsKeyDownTrigger(KK_S))
+	{
+		video.SetState(Video_Skip);
+	}
+#endif // _DEBUG
+
+	//コントローラーの入力の受け取り
+	ControllerState state = GetControllerInput();
+	if (Keyboard_IsKeyDown(KK_SPACE) || (state.buttonA))
+	{
+		skip_cnt += 0.5;
+	}
+	else
+	{
+		if (skip_cnt != 0)
+		{
+			skip_cnt -= 0.5f;
+		}
+
+		if (skip_cnt < 0)
+		{
+			skip_cnt = 0;
+		}
+	}
+
+	if (30 < skip_cnt)
+	{
+  		video.SetState(Video_Skip);
+		skip_cnt = 0;
+	}
+	
+}
+
+void BossMovie::Draw()
+{
+	//バッファクリア
+	Clear();
+
+	if (m_pause)
+	{
+		// シェーダリソースを設定
+		GetDeviceContext()->PSSetShaderResources(0, 1, &g_pause_Texture);
+
+		DrawSpriteOld(
+			{ SCREEN_XCENTER, SCREEN_XCENTER },
+			0.0f,
+			{ 100.0f,100.0f }
+		);
+
+	}
+
+ 	video.Draw(XMFLOAT2(SCREEN_XCENTER, SCREEN_YCENTER),SCREEN_HEIGHT);
+
+	if (g_skip_texture != nullptr)
+	{
+		// シェーダリソースを設定
+		GetDeviceContext()->PSSetShaderResources(0, 1, &g_skip_texture);
+
+		DrawDividedSprite(
+			XMFLOAT2(SCREEN_XCENTER+540, SCREEN_YCENTER + 300),
+			0.0f,
+			XMFLOAT2(200, 70),
+			1, 1, 1
+		);
+	}
+
+	if (g_skip_button_texture != nullptr)
+	{
+		// シェーダリソースを設定
+		GetDeviceContext()->PSSetShaderResources(0, 1, &g_skip_button_texture);
+
+		DrawDividedSprite(
+			XMFLOAT2(SCREEN_XCENTER + 475, SCREEN_YCENTER + 300),
+			0.0f,
+			XMFLOAT2(100, 75),
+			10, 3, skip_cnt
+		);
+	}
+
+	//バックバッファ、フロントバッファ入れ替え
+	Present();
+
+}
+
+void BossMovie::Finalize()
+{
+	video.Finalize();
+	if (g_pause_Texture) { UnInitTexture(g_pause_Texture); }
+	if (g_skip_button_texture) { UnInitTexture(g_skip_button_texture); }
+	if (g_skip_texture) { UnInitTexture(g_skip_texture); }
+	
+}

--- a/boss_movie.cpp
+++ b/boss_movie.cpp
@@ -30,7 +30,7 @@ BossMovie::~BossMovie()
 
 void BossMovie::Initialize()
 {
-	video.Initialize("asset/movie/op.mp4", false);
+	video.Initialize("asset/movie/boss_movie.mp4", false);
 	g_pause_Texture = InitTexture(L"asset\\texture\\sample_texture\\video_pause.png");
 	g_skip_texture = InitTexture(L"asset\\texture\\sample_texture\\skip.png");
 	g_skip_button_texture = InitTexture(L"asset\\texture\\sample_texture\\skip_a.png");

--- a/boss_movie.h
+++ b/boss_movie.h
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------------------------------------
+// #name boss_movie.h
+// #description ボスの登場ムービーを再生するhファイル
+// #make 2025/03/04　yuzu00117
+// #update 2025/03/04
+// #comment 追加・修正予定
+//          
+//----------------------------------------------------------------------------------------------------
+#ifndef BOSS_MOVIE_H
+#define BOSS_MOVIE_H
+
+#include "Video.h"
+
+class BossMovie
+{
+public:
+	BossMovie();
+	~BossMovie();
+
+
+	static BossMovie& GetInstance() {
+		static BossMovie instance;
+		return instance;
+	}
+
+
+
+
+
+
+	void Initialize();
+	void Update();
+	void Draw();
+	void Finalize();
+
+
+private:
+
+	Video video;
+	bool m_pause;
+
+	float skip_cnt;
+
+
+};
+
+
+#endif // !BossMovie_H
+

--- a/contact_block.cpp
+++ b/contact_block.cpp
@@ -136,7 +136,6 @@ void contact_block::Update()
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;
 			case GO_BOSS_MOVIE:
-				sceneManager.SetStageName(STAGE_BOSS);
 				sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;

--- a/contact_block.cpp
+++ b/contact_block.cpp
@@ -124,7 +124,6 @@ void contact_block::Update()
 
 				break;
 			case GO_BOSS_STAGE:
-			
 				sceneManager.SetStageName(STAGE_BOSS);
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;
@@ -133,8 +132,11 @@ void contact_block::Update()
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;
 			case GO_STAGE_SELECT:
-			
 				sceneManager.SetStageName(STAGE_SELECT);
+				sceneManager.Set_Chenge_Scene_flag(true);
+				break;
+			case GO_BOSS_MOVIE:
+				sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;
 			default:

--- a/contact_block.cpp
+++ b/contact_block.cpp
@@ -136,6 +136,7 @@ void contact_block::Update()
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;
 			case GO_BOSS_MOVIE:
+				sceneManager.SetStageName(STAGE_BOSS);
 				sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
 				sceneManager.Set_Chenge_Scene_flag(true);
 				break;

--- a/contact_block.h
+++ b/contact_block.h
@@ -23,6 +23,7 @@ enum Contact_Block_Type
 
 	GO_STAGE_ISEKI,//遺跡のステージにいく
 	GO_BOSS_STAGE,//ボス戦に行く
+	GO_BOSS_MOVIE,//ボス戦ムービーシーンに移行
 
 };
 

--- a/field.cpp
+++ b/field.cpp
@@ -925,7 +925,7 @@ void Field::Initialize()
 			
 					//ボスの登場ムービーシーンに移行
 					if (field_map[y][x] == 70) {
-						objectManager.AddContactBlock(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(2.0f, 10.0f), GO_BOSS_STAGE, b2Vec2_zero);
+						objectManager.AddContactBlock(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(2.0f, 10.0f), GO_BOSS_MOVIE, b2Vec2_zero);
 					}
 
 

--- a/field.cpp
+++ b/field.cpp
@@ -923,7 +923,7 @@ void Field::Initialize()
 					}
 
 			
-					//ボスのステージに行く
+					//ボスの登場ムービーシーンに移行
 					if (field_map[y][x] == 70) {
 						objectManager.AddContactBlock(b2Vec2(x / BOX2D_SCALE_MANAGEMENT, y / BOX2D_SCALE_MANAGEMENT), b2Vec2(2.0f, 10.0f), GO_BOSS_STAGE, b2Vec2_zero);
 					}

--- a/main.cpp
+++ b/main.cpp
@@ -137,9 +137,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 	//開発中はゲームシーンからスタート
 	#ifdef _DEBUG
-	sceneManager.SetStageName(STAGE_BOSS);
+	sceneManager.SetStageName(STAGE_SELECT);
 
-	sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
+	sceneManager.ChangeScene(SCENE_TITLE);
 
 	#else
 	sceneManager.ChangeScene(SCENE_BOSS_MOVIE);

--- a/main.cpp
+++ b/main.cpp
@@ -129,6 +129,8 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	sceneManager.RegisterScene(SCENE_STAGE_SELECT, []() { return std::make_unique<StageSelectScene>(); });
 	sceneManager.RegisterScene(SCENE_GAME, []() { return std::make_unique<GameScene>(); });
 	sceneManager.RegisterScene(SCENE_RESULT, []() { return std::make_unique<ResultScene>(); });
+	sceneManager.RegisterScene(SCENE_BOSS_MOVIE, []() { return std::make_unique<BossMovieScene>(); });
+
 	
 
 	//èâä˙ÉVÅ[ÉìÇÃê›íË
@@ -140,7 +142,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	sceneManager.ChangeScene(SCENE_TITLE);
 
 	#else
-	sceneManager.ChangeScene(SCENE_TITLE);
+	sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
   sceneManager.SetStageName(STAGE_SELECT);
 	#endif
 	

--- a/main.cpp
+++ b/main.cpp
@@ -137,9 +137,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 	//開発中はゲームシーンからスタート
 	#ifdef _DEBUG
-	sceneManager.SetStageName(STAGE_SELECT);
+	sceneManager.SetStageName(STAGE_BOSS);
 
-	sceneManager.ChangeScene(SCENE_TITLE);
+	sceneManager.ChangeScene(SCENE_BOSS_MOVIE);
 
 	#else
 	sceneManager.ChangeScene(SCENE_BOSS_MOVIE);

--- a/scene.h
+++ b/scene.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include"game.h"
 #include"OP.h"
+#include"boss_movie.h"
 #include"sound.h"
 #include"sprite.h"
 #include"include/box2d/box2d.h"
@@ -33,6 +34,7 @@ enum SCENE_NAME
    SCENE_STAGE_SELECT,
    SCENE_GAME,
    SCENE_RESULT,
+   SCENE_BOSS_MOVIE,
 };
 
 
@@ -123,6 +125,32 @@ public :
     }
 
 };
+
+class BossMovieScene : public Scene {
+public:
+    BossMovie& boss_movie = BossMovie::GetInstance();
+
+    void Initialize() override {
+        std::cout << "Boss Movie Scene Initialized" << std::endl;
+        boss_movie.Initialize();
+    }
+
+    void Update() override {
+        std::cout << "Boss Movie Scene Updating" << std::endl;
+        boss_movie.Update();
+    }
+
+    void Draw() override {
+        std::cout << "Boss Movie Scene Drawing" << std::endl;
+        boss_movie.Draw();
+    }
+
+    void Finalize() override {
+        std::cout << "Boss Movie Scene Finalized" << std::endl;
+        boss_movie.Finalize();
+    }
+};
+
 
 class GameScene : public Scene {
 public:


### PR DESCRIPTION
#### PR Classification
新機能の追加。

#### PR Summary
ボスのムービーシーンを管理する新しい機能が追加され、関連するクラスやシーンの処理が更新されました。
- `boss_movie.cpp` にボスムービーを管理する `BossMovie` クラスが実装され、初期化、更新、描画、終了処理のメソッドが追加されました。
- `boss_movie.h` で `BossMovie` クラスの宣言とメンバー変数が定義されました。
- `contact_block.cpp` と `contact_block.h` で、ボスのステージに行く処理がボスのムービーシーンに変更されました。
- `field.cpp` で、特定の条件でボスの登場ムービーシーンに移行する処理が追加されました。
- `main.cpp` で、ボスのムービーシーンが新たに登録され、初期シーンがボスのムービーに変更されました。
