### PR TITLE
エネミーの攻撃のヒープ解消

### DIFF
--- a/enemy_attack.cpp
+++ b/enemy_attack.cpp
@@ -24,6 +24,8 @@
 
 static ID3D11ShaderResourceView* g_EnemyAttack_Texture = NULL;	//動的エネミーのテクスチャ
 
+std::unique_ptr<class ObjectData> g_object_data;
+
 EnemyAttack::EnemyAttack(b2Vec2 position, b2Vec2 body_size, float angle, int id)
 {
 	b2BodyDef body;
@@ -62,10 +64,10 @@ EnemyAttack::EnemyAttack(b2Vec2 position, b2Vec2 body_size, float angle, int id)
 	// カスタムデータを作成して設定
 	// 動的エネミーに値を登録
 	// 動的エネミーにユーザーデータを登録
-	ObjectData* data = new ObjectData{ collider_enemy_attack };
-	enemy_attack_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(data);
-	data->object_name = Object_Enemy_Attack;
-	data->id = id;
+	g_object_data = std::make_unique<ObjectData>(collider_enemy_attack);
+	enemy_attack_fixture->GetUserData().pointer = reinterpret_cast<uintptr_t>(g_object_data.get());
+	g_object_data->object_name = Object_Enemy_Attack;
+	g_object_data->id = id;
 	SetID(id);
 
 	//Initialize();

--- a/enemy_attack.h
+++ b/enemy_attack.h
@@ -12,7 +12,6 @@
 #define ENEMY_ATTACK_H
 
 #include "enemy.h"
-#include "player_stamina.h"
 
 //==========É}ÉNÉçíËã`==========//
 #define ENEMY_ATTACK_DAMAGE (100)


### PR DESCRIPTION
グローバル変数にスマートポインタを用意し、それを用いています。
攻撃生成の度にスマートポインタ内のidは上書きされますが、ゲーム確認した感じ挙動等に問題なさそうです